### PR TITLE
fix(certify-service): correct EntityScan basePackages configuration

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/config/AppConfig.java
+++ b/certify-service/src/main/java/io/mosip/certify/config/AppConfig.java
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @EnableJpaRepositories(basePackages = {"io.mosip.kernel.keymanagerservice.repository", "io.mosip.certify.repository"})
-@EntityScan(basePackages = {"io.mosip.kernel.keymanagerservice.entity, io.mosip.certify.entity"})
+@EntityScan(basePackages = {"io.mosip.kernel.keymanagerservice.entity", "io.mosip.certify.entity"})
 @Slf4j
 public class AppConfig implements ApplicationRunner {
 


### PR DESCRIPTION
﻿## Summary
Fixes `@EntityScan` package configuration in `AppConfig` by splitting a comma-joined package token into two valid package entries.

### Before
`@EntityScan(basePackages = {"io.mosip.kernel.keymanagerservice.entity, io.mosip.certify.entity"})`

### After
`@EntityScan(basePackages = {"io.mosip.kernel.keymanagerservice.entity", "io.mosip.certify.entity"})`

## Why
`basePackages` expects one package per array item. A combined token can cause incorrect/ambiguous entity scanning behavior.

## Scope
- `certify-service/src/main/java/io/mosip/certify/config/AppConfig.java`
- No other functional changes.

Fixes #849
