### PR TITLE
fix(#865): correct AccessDeniedHandler to avoid invalid request casting

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -11,6 +11,7 @@ import io.mosip.certify.core.dto.VCError;
 import io.mosip.certify.core.dto.OAuthTokenError;
 import io.mosip.certify.core.exception.*;
 import io.mosip.certify.core.util.CommonUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,6 +54,9 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
 
     @Autowired
     MessageSource messageSource;
+
+    @Autowired
+    ObjectMapper objectMapper;
 
     @Override
     protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers,
@@ -245,7 +249,13 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
-        handleExceptions(accessDeniedException, (WebRequest) request);
+        log.error("Access denied while handling request {} {}", request.getMethod(), request.getRequestURI(), accessDeniedException);
+        ResponseWrapper responseWrapper = getResponseWrapper(HttpStatus.FORBIDDEN.name(), "Access denied");
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), responseWrapper);
     }
 
     private String getMessage(String errorCode, String defaultMessage) {


### PR DESCRIPTION
### Summary  
fix(#865 ): correct AccessDeniedHandler to prevent runtime casting failure

### Description  
The AccessDeniedHandler in ExceptionHandlerAdvice.java incorrectly cast HttpServletRequest to WebRequest, which is not a compatible type.

This caused:

- Runtime ClassCastException during access-denied (403) scenarios  
- Broken error handling flow  
- Incorrect or unexpected server responses  

### Root Cause  
The handler relied on an invalid type cast between HttpServletRequest and WebRequest. Since these types are not interchangeable in Spring, the cast failed at runtime when invoked by Spring Security.

### Changes  
- Removed invalid casting from HttpServletRequest to WebRequest  
- Updated handler to use HttpServletRequest and HttpServletResponse directly  
- Ensured consistent JSON error response using existing response structure  
- Explicitly set HTTP 403 status for access-denied cases  

### Validation  
- Verified access-denied scenarios return HTTP 403  
- Confirmed no runtime exceptions occur  
- Checked response format matches existing JSON error structure  
- Ensured behavior is consistent with other exception handlers  

### Behavior  
- No change for valid authorization flows  
- Improved handling of access-denied cases with stable and predictable responses  

### Closes  
Closes #865 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Access-denied scenarios now return consistent 403 Forbidden responses with standardized JSON error messages, improving clarity and reliability for users when permissions are insufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->