### PR TITLE
INJICERT #869 - fix: atomically claim only unexpired codes

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
@@ -316,7 +316,7 @@ public class PreAuthorizedCodeService {
 
         // Reject unknown codes immediately before any expiry or claim check
         if (codeData == null) {
-            log.error("Pre-authorized code not found: {}", request.getPre_authorized_code());
+            log.error("Pre-authorized code not found");
             throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code not found");
         }
 

--- a/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
@@ -320,16 +320,15 @@ public class PreAuthorizedCodeService {
             throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code not found");
         }
 
-        // Check expiry before claiming so expired codes are never consumed
+        // Atomically validate expiry and claim to avoid TOCTOU around expiry boundary
         long currentTime = System.currentTimeMillis();
-        if (codeData.getExpiresAt() < currentTime) {
+        VCICacheService.PreAuthCodeClaimResult claimResult =
+                vciCacheService.claimPreAuthCodeIfUnexpired(request.getPre_authorized_code(), currentTime);
+        if (claimResult == VCICacheService.PreAuthCodeClaimResult.EXPIRED) {
             log.error("Pre-authorized code expired. Expiry: {}, Current: {}", codeData.getExpiresAt(), currentTime);
             throw new CertifyException("pre_auth_code_expired", "Pre-authorized code has expired");
         }
-
-        // Atomically claim the pre-authorized code (single-use enforcement)
-        boolean claimed = vciCacheService.claimPreAuthCode(request.getPre_authorized_code());
-        if (!claimed) {
+        if (claimResult == VCICacheService.PreAuthCodeClaimResult.INVALID_OR_USED) {
             log.error("Pre-authorized code already used or invalid");
             throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code has already been used  or invalid");
         }

--- a/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/PreAuthorizedCodeService.java
@@ -314,18 +314,24 @@ public class PreAuthorizedCodeService {
             throw new CertifyException(ErrorConstants.UNSUPPORTED_GRANT_TYPE, "Grant type not supported");
         }
 
-        // Atomically claim the pre-authorized code
-        boolean claimed = vciCacheService.claimPreAuthCode(request.getPre_authorized_code());
-        if (!claimed) {
-            log.error("Pre-authorized code already used or invalid");
-            throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code has already been used  or invalid");
+        // Reject unknown codes immediately before any expiry or claim check
+        if (codeData == null) {
+            log.error("Pre-authorized code not found: {}", request.getPre_authorized_code());
+            throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code not found");
         }
 
-        // Check expiry
+        // Check expiry before claiming so expired codes are never consumed
         long currentTime = System.currentTimeMillis();
         if (codeData.getExpiresAt() < currentTime) {
             log.error("Pre-authorized code expired. Expiry: {}, Current: {}", codeData.getExpiresAt(), currentTime);
             throw new CertifyException("pre_auth_code_expired", "Pre-authorized code has expired");
+        }
+
+        // Atomically claim the pre-authorized code (single-use enforcement)
+        boolean claimed = vciCacheService.claimPreAuthCode(request.getPre_authorized_code());
+        if (!claimed) {
+            log.error("Pre-authorized code already used or invalid");
+            throw new CertifyException(ErrorConstants.INVALID_GRANT, "Pre-authorized code has already been used  or invalid");
         }
 
         // Validate transaction code if required

--- a/certify-service/src/main/java/io/mosip/certify/services/VCICacheService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/VCICacheService.java
@@ -21,6 +21,12 @@ import org.springframework.stereotype.Service;
 @Service
 public class VCICacheService {
 
+    public enum PreAuthCodeClaimResult {
+        CLAIMED,
+        EXPIRED,
+        INVALID_OR_USED
+    }
+
     @Autowired
     private CacheManager cacheManager;
 
@@ -155,6 +161,22 @@ public class VCICacheService {
             }
             markPreAuthCodeAsUsed(preAuthCode);
             return true;
+        }
+    }
+
+    public PreAuthCodeClaimResult claimPreAuthCodeIfUnexpired(String preAuthCode, long currentTime) {
+        synchronized (this) {
+            PreAuthCodeData codeData = getPreAuthCodeData(preAuthCode);
+            if (codeData == null || isPreAuthCodeUsed(preAuthCode)) {
+                return PreAuthCodeClaimResult.INVALID_OR_USED;
+            }
+
+            if (codeData.getExpiresAt() < currentTime) {
+                return PreAuthCodeClaimResult.EXPIRED;
+            }
+
+            markPreAuthCodeAsUsed(preAuthCode);
+            return PreAuthCodeClaimResult.CLAIMED;
         }
     }
 

--- a/certify-service/src/main/java/io/mosip/certify/services/VCICacheService.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/VCICacheService.java
@@ -153,17 +153,6 @@ public class VCICacheService {
         return wrapper != null && Boolean.TRUE.equals(wrapper.get());
     }
 
-    public boolean claimPreAuthCode(String preAuthCode) {
-        synchronized (this) {
-            PreAuthCodeData codeData = getPreAuthCodeData(preAuthCode);
-            if (codeData == null || isPreAuthCodeUsed(preAuthCode)) {
-                return false;
-            }
-            markPreAuthCodeAsUsed(preAuthCode);
-            return true;
-        }
-    }
-
     public PreAuthCodeClaimResult claimPreAuthCodeIfUnexpired(String preAuthCode, long currentTime) {
         synchronized (this) {
             PreAuthCodeData codeData = getPreAuthCodeData(preAuthCode);

--- a/certify-service/src/test/java/io/mosip/certify/VCICacheServiceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/VCICacheServiceTest.java
@@ -244,6 +244,25 @@ public class VCICacheServiceTest {
     }
 
     @Test
+    public void claimPreAuthCodeIfUnexpired_WhenExpired_ReturnsExpiredWithoutClaiming() {
+        String code = "expired-code";
+        long currentTime = System.currentTimeMillis();
+        PreAuthCodeData data = PreAuthCodeData.builder()
+                .expiresAt(currentTime - 1)
+                .build();
+        Cache.ValueWrapper wrapper = mock(Cache.ValueWrapper.class);
+        when(wrapper.get()).thenReturn(data);
+        when(cache.get(Constants.PRE_AUTH_CODE_PREFIX + code)).thenReturn(wrapper);
+
+        VCICacheService.PreAuthCodeClaimResult result =
+                vciCacheService.claimPreAuthCodeIfUnexpired(code, currentTime);
+
+        assertEquals(VCICacheService.PreAuthCodeClaimResult.EXPIRED, result);
+        verify(cache, never()).put("used:" + code, true);
+        verify(cache, never()).evict(Constants.PRE_AUTH_CODE_PREFIX + code);
+    }
+
+    @Test
     public void markPreAuthCodeAsUsed_Success() {
         String code = "code-to-mark";
         String usedKey = "used:" + code;

--- a/certify-service/src/test/java/io/mosip/certify/services/PreAuthorizedCodeServiceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/PreAuthorizedCodeServiceTest.java
@@ -418,12 +418,13 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));
 
         Assert.assertEquals("pre_auth_code_expired", exception.getErrorCode());
+        // Expired codes must never be consumed — claiming would corrupt single-use semantics
+        verify(vciCacheService, never()).claimPreAuthCode(preAuthCode);
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/services/PreAuthorizedCodeServiceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/PreAuthorizedCodeServiceTest.java
@@ -319,7 +319,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.CLAIMED);
         when(vciCacheService.setPreAuthTransaction(anyString(), any(PreAuthTransaction.class))).thenReturn(null);
         when(accessTokenJwtUtil.generateSignedJwt(anyString(), anyString(), anyString(), anyString(), anyString(), anyInt()))
                 .thenReturn("test.jwt.token");
@@ -333,7 +334,7 @@ public class PreAuthorizedCodeServiceTest {
         Assert.assertEquals(Integer.valueOf(600), response.getExpiresIn());
 
         verify(vciCacheService).getPreAuthCodeData(preAuthCode);
-        verify(vciCacheService).claimPreAuthCode(preAuthCode);
+        verify(vciCacheService).claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong());
         verify(vciCacheService).setPreAuthTransaction(anyString(), any(PreAuthTransaction.class));
     }
 
@@ -358,7 +359,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.CLAIMED);
         when(vciCacheService.setPreAuthTransaction(anyString(), any(PreAuthTransaction.class))).thenReturn(null);
         when(accessTokenJwtUtil.generateSignedJwt(anyString(), anyString(), anyString(), anyString(), anyString(), anyInt()))
                 .thenReturn("test.jwt.token");
@@ -367,7 +369,7 @@ public class PreAuthorizedCodeServiceTest {
 
         Assert.assertNotNull(response);
         Assert.assertNotNull(response.getAccessToken());
-        verify(vciCacheService).claimPreAuthCode(preAuthCode);
+        verify(vciCacheService).claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong());
     }
 
     @Test
@@ -418,13 +420,15 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.EXPIRED);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));
 
         Assert.assertEquals("pre_auth_code_expired", exception.getErrorCode());
-        // Expired codes must never be consumed — claiming would corrupt single-use semantics
-        verify(vciCacheService, never()).claimPreAuthCode(preAuthCode);
+        // Expiry and claim are validated atomically in cache layer
+        verify(vciCacheService).claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong());
     }
 
     @Test
@@ -441,7 +445,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(false);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.INVALID_OR_USED);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));
@@ -464,7 +469,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.CLAIMED);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));
@@ -488,7 +494,8 @@ public class PreAuthorizedCodeServiceTest {
                 .build();
 
         when(vciCacheService.getPreAuthCodeData(preAuthCode)).thenReturn(codeData);
-        when(vciCacheService.claimPreAuthCode(preAuthCode)).thenReturn(true);
+        when(vciCacheService.claimPreAuthCodeIfUnexpired(eq(preAuthCode), anyLong()))
+                .thenReturn(VCICacheService.PreAuthCodeClaimResult.CLAIMED);
 
         CertifyException exception = assertThrows(CertifyException.class,
                 () -> preAuthorizedCodeService.exchangePreAuthorizedCode(tokenRequest));


### PR DESCRIPTION
### Description

Pre-authorized codes were being claimed (marked used) before the expiry check ran. This meant an expired code got consumed, so the caller received `invalid_grant` instead of `pre_auth_code_expired`. Under concurrent requests there was also a race window where two threads could both pass the expiry check before either marked the code as used.

**Before:** expired code was consumed then threw `invalid_grant`
**After:** expired code is never consumed and throws `pre_auth_code_expired`

### Changes

- Added `claimPreAuthCodeIfUnexpired()` to `VCICacheService` — a single `synchronized` method that atomically checks null/used → expiry → marks used → returns a `PreAuthCodeClaimResult` enum (`CLAIMED`, `EXPIRED`, `INVALID_OR_USED`)
- Updated `PreAuthorizedCodeService.validateTokenRequest()` to call this method instead of separate claim + expiry steps
- Updated unit tests to mock the new method and assert correct error codes per scenario

### Test Output
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS


Closes #869

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved pre-authorized code validation, including clearer handling of missing, expired, invalid, and already-used codes.
* Prevented expired codes from being accepted or incorrectly marked as used.

## Improvements
* Strengthened the pre-authorization authentication flow with more reliable, atomic code-claim handling.
* Preserved transaction-code validation while providing more accurate outcomes for authorization-code exchanges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->