### PR TITLE
[INJICERT-1260] Added proper validation in credential status update

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -93,4 +93,6 @@ public class ErrorConstants {
     public static final String INVALID_AUTHORIZATION_SERVER = "invalid_authorization_server";
     public static final String AUTHORIZATION_SERVER_NOT_CONFIGURED = "authorization_server_not_configured";
     public static final String INVALID_CREDENTIAL_REQUEST = "invalid_credential_request";
+    public static final String INVALID_STATUS_LIST_INDEX = "invalid_status_list_index";
+    public static final String STATUS_LIST_INDEX_OUT_OF_RANGE = "status_list_index_out_of_range";
 }

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -12,22 +12,35 @@ import io.mosip.certify.repository.StatusListCredentialRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
 public class CredentialStatusServiceImpl implements CredentialStatusService {
+    public static final int DEFAULT_STATUS_LIST_SIZE = 131072;
     @Autowired
     private CredentialStatusTransactionRepository credentialStatusTransactionRepository;
 
     @Autowired
     private StatusListCredentialRepository statusListCredentialRepository;
 
+    @Value("#{${mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes:{}}}")
+    private List<String> allowedCredentialStatusPurposes;
+
     @Override
     public CredentialStatusResponse updateCredentialStatus(UpdateCredentialStatusRequest request) {
+
         String statusListCredentialId = request.getCredentialStatus().getStatusListCredential();
         Long statusListIndex = request.getCredentialStatus().getStatusListIndex();
         String id = request.getCredentialStatus().getId();
+
+        String statusPurpose = validateAndGetStatusPurpose(
+                request.getCredentialStatus() == null ? null : request.getCredentialStatus().getStatusPurpose()
+        );
+        validateStatusListIndex(statusListIndex);
 
         if(id != null && !id.equals(statusListCredentialId)) {
             throw new CertifyException(ErrorConstants.STATUS_ID_MISMATCH, "Mismatch between credential status ID and Status List Credential.");
@@ -36,11 +49,7 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
                 .orElseThrow(() -> new CertifyException(ErrorConstants.STATUS_LIST_NOT_FOUND, "Status List Credential not found for ID: " + statusListCredentialId));
 
         CredentialStatusTransaction transaction = new CredentialStatusTransaction();
-        if(StringUtils.isEmpty(request.getCredentialStatus().getStatusPurpose())) {
-            transaction.setStatusPurpose(statusListCredential.getStatusPurpose());
-        } else {
-            transaction.setStatusPurpose(request.getCredentialStatus().getStatusPurpose());
-        }
+        transaction.setStatusPurpose(statusPurpose);
         transaction.setStatusValue(request.getStatus());
         transaction.setStatusListCredentialId(statusListCredentialId);
         transaction.setStatusListIndex(statusListIndex);
@@ -55,5 +64,36 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
             dto.setCredentialType(request.getCredentialStatus().getType());
         }
         return dto;
+    }
+
+    private String validateAndGetStatusPurpose(String statusPurpose) {
+        if(allowedCredentialStatusPurposes == null || allowedCredentialStatusPurposes.isEmpty()) {
+            throw new CertifyException(ErrorConstants.INVALID_STATUS_PURPOSE, "No allowed status purposes configured.");
+        }
+        // fallback to revocation when statusPurpose is missing or empty
+        if(statusPurpose == null || statusPurpose.trim().isEmpty()) {
+            return allowedCredentialStatusPurposes.get(0);
+        }
+        String statusPurposeValue = statusPurpose.trim().toLowerCase();
+        boolean isAllowed = allowedCredentialStatusPurposes.stream()
+                .anyMatch(allowed -> allowed.equalsIgnoreCase(statusPurposeValue));
+        if (!isAllowed) {
+            throw new CertifyException(ErrorConstants.INVALID_STATUS_PURPOSE,
+                    "statusPurpose must be one of: " + allowedCredentialStatusPurposes);
+        }
+        return statusPurposeValue;
+    }
+
+    private void validateStatusListIndex(Long statusListIndex) {
+        if (statusListIndex == null) {
+            throw new CertifyException(ErrorConstants.INVALID_STATUS_LIST_INDEX, "statusListIndex must not be null");
+        }
+        if(statusListIndex < 0) {
+            throw new CertifyException(ErrorConstants.INVALID_STATUS_LIST_INDEX, "statusListIndex must be a non-negative integer");
+        }
+        if(statusListIndex >= DEFAULT_STATUS_LIST_SIZE) {
+            String errorMsg = String.format("statusListIndex must be between 0 and %d", DEFAULT_STATUS_LIST_SIZE - 1);
+            throw new CertifyException(ErrorConstants.STATUS_LIST_INDEX_OUT_OF_RANGE, errorMsg);
+        }
     }
 }

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -27,6 +27,7 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
     @Autowired
     private StatusListCredentialRepository statusListCredentialRepository;
 
+    // {} is SpEL inline-list syntax (not a map); evaluates to empty List<String> when property is unset
     @Value("#{${mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes:{}}}")
     private List<String> allowedCredentialStatusPurposes;
 
@@ -46,7 +47,7 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
         String statusPurpose = validateAndGetStatusPurpose(
                 request.getCredentialStatus().getStatusPurpose(), statusListCredential
         );
-        validateStatusListIndex(statusListIndex);
+        validateStatusListIndex(statusListIndex, statusListCredential.getCapacityInKB());
 
         CredentialStatusTransaction transaction = new CredentialStatusTransaction();
         transaction.setStatusPurpose(statusPurpose);
@@ -84,15 +85,16 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
         return statusPurposeValue;
     }
 
-    private void validateStatusListIndex(Long statusListIndex) {
+    private void validateStatusListIndex(Long statusListIndex, Long capacityInKB) {
         if (statusListIndex == null) {
             throw new CertifyException(ErrorConstants.INVALID_STATUS_LIST_INDEX, "statusListIndex must not be null");
         }
         if(statusListIndex < 0) {
             throw new CertifyException(ErrorConstants.INVALID_STATUS_LIST_INDEX, "statusListIndex must be a non-negative integer");
         }
-        if(statusListIndex >= DEFAULT_STATUS_LIST_SIZE) {
-            String errorMsg = String.format("statusListIndex must be between 0 and %d", DEFAULT_STATUS_LIST_SIZE - 1);
+        long maxIndex = (capacityInKB != null) ? capacityInKB * 1024L * 8L : DEFAULT_STATUS_LIST_SIZE;
+        if(statusListIndex >= maxIndex) {
+            String errorMsg = String.format("statusListIndex must be between 0 and %d", maxIndex - 1);
             throw new CertifyException(ErrorConstants.STATUS_LIST_INDEX_OUT_OF_RANGE, errorMsg);
         }
     }

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -27,7 +27,7 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
     @Autowired
     private StatusListCredentialRepository statusListCredentialRepository;
 
-    @Value("#{${mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes:{}}}")
+    @Value("#{${mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes:[]}}")
     private List<String> allowedCredentialStatusPurposes;
 
     @Override

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -37,16 +37,16 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
         Long statusListIndex = request.getCredentialStatus().getStatusListIndex();
         String id = request.getCredentialStatus().getId();
 
-        String statusPurpose = validateAndGetStatusPurpose(
-                request.getCredentialStatus() == null ? null : request.getCredentialStatus().getStatusPurpose()
-        );
-        validateStatusListIndex(statusListIndex);
-
         if(id != null && !id.equals(statusListCredentialId)) {
             throw new CertifyException(ErrorConstants.STATUS_ID_MISMATCH, "Mismatch between credential status ID and Status List Credential.");
         }
         StatusListCredential statusListCredential = statusListCredentialRepository.findById(statusListCredentialId)
                 .orElseThrow(() -> new CertifyException(ErrorConstants.STATUS_LIST_NOT_FOUND, "Status List Credential not found for ID: " + statusListCredentialId));
+
+        String statusPurpose = validateAndGetStatusPurpose(
+                request.getCredentialStatus().getStatusPurpose(), statusListCredential
+        );
+        validateStatusListIndex(statusListIndex);
 
         CredentialStatusTransaction transaction = new CredentialStatusTransaction();
         transaction.setStatusPurpose(statusPurpose);
@@ -66,20 +66,20 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
         return dto;
     }
 
-    private String validateAndGetStatusPurpose(String statusPurpose) {
-        if(allowedCredentialStatusPurposes == null || allowedCredentialStatusPurposes.isEmpty()) {
-            throw new CertifyException(ErrorConstants.INVALID_STATUS_PURPOSE, "No allowed status purposes configured.");
-        }
-        // fallback to revocation when statusPurpose is missing or empty
+    private String validateAndGetStatusPurpose(String statusPurpose, StatusListCredential statusListCredential) {
+        // fallback to StatusListCredential's purpose when statusPurpose is missing or empty
         if(statusPurpose == null || statusPurpose.trim().isEmpty()) {
-            return allowedCredentialStatusPurposes.get(0);
+            return statusListCredential.getStatusPurpose();
         }
         String statusPurposeValue = statusPurpose.trim().toLowerCase();
-        boolean isAllowed = allowedCredentialStatusPurposes.stream()
-                .anyMatch(allowed -> allowed.equalsIgnoreCase(statusPurposeValue));
-        if (!isAllowed) {
-            throw new CertifyException(ErrorConstants.INVALID_STATUS_PURPOSE,
-                    "statusPurpose must be one of: " + allowedCredentialStatusPurposes);
+        // validate against allowed purposes only if the list is configured
+        if(allowedCredentialStatusPurposes != null && !allowedCredentialStatusPurposes.isEmpty()) {
+            boolean isAllowed = allowedCredentialStatusPurposes.stream()
+                    .anyMatch(allowed -> allowed.equalsIgnoreCase(statusPurposeValue));
+            if (!isAllowed) {
+                throw new CertifyException(ErrorConstants.INVALID_STATUS_PURPOSE,
+                        "statusPurpose must be one of: " + allowedCredentialStatusPurposes);
+            }
         }
         return statusPurposeValue;
     }

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -27,7 +27,7 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
     @Autowired
     private StatusListCredentialRepository statusListCredentialRepository;
 
-    @Value("#{${mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes:[]}}")
+    @Value("#{${mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes:{}}}")
     private List<String> allowedCredentialStatusPurposes;
 
     @Override

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
@@ -123,14 +123,59 @@ public class CredentialStatusServiceImplTest {
     public void updateCredentialStatusV2_NullStatusListIndex_ThrowsException() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
-        request.getCredentialStatus().setStatusListIndex(null); // Null StatusListIndex
+        request.getCredentialStatus().setStatusListIndex(null);
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(16L);
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
 
         CertifyException exception = assertThrows(CertifyException.class, () -> {
             credentialStatusService.updateCredentialStatus(request);
         });
 
-        assertEquals("status_list_not_found_for_the_given_id", exception.getErrorCode());
-        assertEquals("Status List Credential not found for ID: https://example.com/status-list/xyz#87823", exception.getMessage());
+        assertEquals("invalid_status_list_index", exception.getErrorCode());
+        assertEquals("statusListIndex must not be null", exception.getMessage());
+    }
+
+    @Test
+    public void updateCredentialStatusV2_IndexExceedsActualCapacity_ThrowsException() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+        // capacity = 1 KB = 8192 bits, so index 87823 is out of range
+        request.getCredentialStatus().setStatusListIndex(87823L);
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(1L);
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
+
+        CertifyException exception = assertThrows(CertifyException.class, () -> {
+            credentialStatusService.updateCredentialStatus(request);
+        });
+
+        assertEquals("status_list_index_out_of_range", exception.getErrorCode());
+    }
+
+    @Test
+    public void updateCredentialStatusV2_NullCapacityFallsBackToDefault_Succeeds() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(null); // no capacity set, should fall back to DEFAULT_STATUS_LIST_SIZE
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
+        when(credentialStatusTransactionRepository.save(any(CredentialStatusTransaction.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CredentialStatusResponse response = credentialStatusService.updateCredentialStatus(request);
+
+        assertNotNull(response);
+        assertEquals(87823L, response.getStatusListIndex());
     }
 
     @Test


### PR DESCRIPTION
### Issue Identified

#700 

- statusPurpose accepted any random/empty value and did not default to the configured value (revocation) when omitted.
- statusListIndex was not validated for being a non‑negative integer or for staying within the valid range of the status list.

### Expected Behaviour

- statusPurpose must match supported types; if missing, it should default to revocation. Invalid or empty values should return a validation error.
- statusListIndex must be a non‑negative integer and within the bounds of the corresponding status list size.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error reporting for credential status updates, including new error codes for `invalid_status_list_index` and `status_list_index_out_of_range`.
  * Status list index is now rejected when null, negative, or outside the allowed range (with clearer `[0..max]` guidance).
  * Request-provided status purpose is normalized (trimmed, case-insensitive) and validated against configured allowed purposes when present.
* **Tests**
  * Added/updated coverage for null index, out-of-range index, and null capacity fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->