### PR TITLE
INJICERT-878 added proper error messages for negative scenarios

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -12,6 +12,7 @@ public class ErrorConstants {
     public static final String INVALID_AUTH_TOKEN = "invalid_token";
     public static final String INVALID_ALGORITHM = "invalid_algorithm";
     public static final String UNKNOWN_ERROR = "unknown_error";
+    public static final String CREDENTIAL_NOT_FOUND = "credential_not_found";
     public static final String INVALID_VC_FORMAT = "invalid_vc_format";
     public static final String UNSUPPORTED_PROOF_TYPE = "unsupported_proof_type";
     public static final String VC_ISSUANCE_FAILED = "vc_issuance_failed";

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialRequest.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialRequest.java
@@ -11,12 +11,14 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.Map;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CredentialRequest {
 
     @NotBlank(message = ErrorConstants.INVALID_CREDENTIAL_REQUEST)

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/UpdateCredentialStatusRequest.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/UpdateCredentialStatusRequest.java
@@ -1,11 +1,15 @@
 package io.mosip.certify.core.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 public class UpdateCredentialStatusRequest {
+    @NotBlank
+    private String credentialId;
+
     @NotNull
     @Valid
     private CredentialStatusDto credentialStatus;

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/UpdateCredentialStatusRequest.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/UpdateCredentialStatusRequest.java
@@ -1,11 +1,13 @@
 package io.mosip.certify.core.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UpdateCredentialStatusRequest {
     @NotBlank
     private String credentialId;
@@ -21,6 +23,7 @@ public class UpdateCredentialStatusRequest {
     public static class CredentialStatusDto {
         private String id;
         private String type;
+        @NotNull
         private String statusPurpose;
         @NotNull
         private Long statusListIndex;

--- a/certify-core/src/main/java/io/mosip/certify/core/dto/UpdateCredentialStatusRequest.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/UpdateCredentialStatusRequest.java
@@ -2,16 +2,12 @@ package io.mosip.certify.core.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UpdateCredentialStatusRequest {
-    @NotBlank
-    private String credentialId;
-
     @NotNull
     @Valid
     private CredentialStatusDto credentialStatus;

--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -106,6 +106,9 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
 
 
     private ResponseEntity<ResponseWrapper> handleInternalControllerException(Exception ex) {
+        if(ex instanceof HttpMessageNotReadableException) {
+            return new ResponseEntity<ResponseWrapper>(getResponseWrapper(INVALID_REQUEST, ex.getMessage()), HttpStatus.BAD_REQUEST);
+        }
         if(ex instanceof MethodArgumentNotValidException) {
             List<Error> errors = new ArrayList<>();
             for (FieldError error : ((MethodArgumentNotValidException) ex).getBindingResult().getFieldErrors()) {
@@ -132,6 +135,9 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
         if(ex instanceof CertifyException) {
             String errorCode = ((CertifyException) ex).getErrorCode();
             String errorMessage = ex.getMessage();
+            if(CREDENTIAL_NOT_FOUND.equals(errorCode)) {
+                return new ResponseEntity<>(getResponseWrapper(errorCode, errorMessage), HttpStatus.NOT_FOUND);
+            }
             return new ResponseEntity<ResponseWrapper>(getResponseWrapper(errorCode, errorMessage), HttpStatus.OK);
         }
         if(ex instanceof RenderingTemplateException) {
@@ -152,6 +158,9 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
     }
 
     public ResponseEntity<VCError> handleVCIControllerExceptions(Exception ex) {
+        if(ex instanceof HttpMessageNotReadableException) {
+            return new ResponseEntity<>(getVCErrorDto(INVALID_CREDENTIAL_REQUEST, ex.getMessage()), HttpStatus.BAD_REQUEST);
+        }
         if(ex instanceof MethodArgumentNotValidException) {
             FieldError fieldError = ((MethodArgumentNotValidException) ex).getBindingResult().getFieldError();
             String message = fieldError != null ? fieldError.getDefaultMessage() : ex.getMessage();

--- a/certify-service/src/main/java/io/mosip/certify/proof/DIDkeysProofManager.java
+++ b/certify-service/src/main/java/io/mosip/certify/proof/DIDkeysProofManager.java
@@ -39,7 +39,12 @@ public class DIDkeysProofManager implements JwtProofKeyManager {
         if (hashIdx != -1) {
             multibase = multibase.substring(0, hashIdx);
         }
-        byte[] b = Multibase.decode(multibase);
+        byte[] b;
+        try {
+            b = Multibase.decode(multibase);
+        } catch (RuntimeException e) {
+            return Optional.empty();
+        }
 
         // full list of keys and their multibase prefixes available here: https://github.com/multiformats/multicodec/blob/master/table.csv
         // NOTE: https://w3c-ccg.github.io/did-key-spec/#signature-method-creation-algorithm

--- a/certify-service/src/main/java/io/mosip/certify/proof/JwtProofValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/proof/JwtProofValidator.java
@@ -142,6 +142,8 @@ public class JwtProofValidator implements ProofValidator {
             log.error("Failed to parse jwt in the credential proof", e);
         } catch (BadJOSEException | JOSEException e) {
             log.error("JWT proof verification failed", e);
+        } catch (Exception e) {
+            log.error("Unexpected exception during proof validation", e);
         }
         return false;
     }

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -31,7 +31,7 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
     @Override
     public CredentialStatusResponse updateCredentialStatus(UpdateCredentialStatusRequest request) {
         String statusPurpose = request.getCredentialStatus().getStatusPurpose();
-        if (!allowedCredentialStatusPurposes.isEmpty() && !allowedCredentialStatusPurposes.contains(statusPurpose)) {
+        if (allowedCredentialStatusPurposes != null && !allowedCredentialStatusPurposes.isEmpty() && !allowedCredentialStatusPurposes.contains(statusPurpose)) {
             throw new CertifyException(ErrorConstants.INVALID_STATUS_PURPOSE,
                     "Invalid credential status purpose. Allowed values are: " + allowedCredentialStatusPurposes);
         }

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -8,6 +8,7 @@ import io.mosip.certify.core.spi.CredentialStatusService;
 import io.mosip.certify.entity.CredentialStatusTransaction;
 import io.mosip.certify.entity.StatusListCredential;
 import io.mosip.certify.repository.CredentialStatusTransactionRepository;
+import io.mosip.certify.repository.LedgerRepository;
 import io.mosip.certify.repository.StatusListCredentialRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -23,8 +24,15 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
     @Autowired
     private StatusListCredentialRepository statusListCredentialRepository;
 
+    @Autowired
+    private LedgerRepository ledgerRepository;
+
     @Override
     public CredentialStatusResponse updateCredentialStatus(UpdateCredentialStatusRequest request) {
+        ledgerRepository.findByCredentialId(request.getCredentialId())
+                .orElseThrow(() -> new CertifyException(ErrorConstants.CREDENTIAL_NOT_FOUND,
+                        "Credential not found for ID: " + request.getCredentialId()));
+
         String statusListCredentialId = request.getCredentialStatus().getStatusListCredential();
         Long statusListIndex = request.getCredentialStatus().getStatusListIndex();
         String id = request.getCredentialStatus().getId();

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -8,12 +8,13 @@ import io.mosip.certify.core.spi.CredentialStatusService;
 import io.mosip.certify.entity.CredentialStatusTransaction;
 import io.mosip.certify.entity.StatusListCredential;
 import io.mosip.certify.repository.CredentialStatusTransactionRepository;
-import io.mosip.certify.repository.LedgerRepository;
 import io.mosip.certify.repository.StatusListCredentialRepository;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -24,14 +25,16 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
     @Autowired
     private StatusListCredentialRepository statusListCredentialRepository;
 
-    @Autowired
-    private LedgerRepository ledgerRepository;
+    @Value("#{${mosip.certify.data-provider-plugin.credential-status.allowed-status-purposes:{}}}")
+    private List<String> allowedCredentialStatusPurposes;
 
     @Override
     public CredentialStatusResponse updateCredentialStatus(UpdateCredentialStatusRequest request) {
-        ledgerRepository.findByCredentialId(request.getCredentialId())
-                .orElseThrow(() -> new CertifyException(ErrorConstants.CREDENTIAL_NOT_FOUND,
-                        "Credential not found for ID: " + request.getCredentialId()));
+        String statusPurpose = request.getCredentialStatus().getStatusPurpose();
+        if (!allowedCredentialStatusPurposes.isEmpty() && !allowedCredentialStatusPurposes.contains(statusPurpose)) {
+            throw new CertifyException(ErrorConstants.INVALID_STATUS_PURPOSE,
+                    "Invalid credential status purpose. Allowed values are: " + allowedCredentialStatusPurposes);
+        }
 
         String statusListCredentialId = request.getCredentialStatus().getStatusListCredential();
         Long statusListIndex = request.getCredentialStatus().getStatusListIndex();
@@ -44,11 +47,7 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
                 .orElseThrow(() -> new CertifyException(ErrorConstants.STATUS_LIST_NOT_FOUND, "Status List Credential not found for ID: " + statusListCredentialId));
 
         CredentialStatusTransaction transaction = new CredentialStatusTransaction();
-        if(StringUtils.isEmpty(request.getCredentialStatus().getStatusPurpose())) {
-            transaction.setStatusPurpose(statusListCredential.getStatusPurpose());
-        } else {
-            transaction.setStatusPurpose(request.getCredentialStatus().getStatusPurpose());
-        }
+        transaction.setStatusPurpose(request.getCredentialStatus().getStatusPurpose());
         transaction.setStatusValue(request.getStatus());
         transaction.setStatusListCredentialId(statusListCredentialId);
         transaction.setStatusListIndex(statusListIndex);

--- a/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
@@ -42,8 +42,7 @@ public class VCIssuanceUtil {
             }
         }
         catch (ParseException e) {
-            // check iff specific error exists for invalid holderKey
-            throw new CertifyException(VCIErrorConstants.INVALID_PROOF, "Error encountered during proof jwt parsing.");
+            throw new CertifyException(VCIErrorConstants.INVALID_CREDENTIAL_REQUEST, "Error encountered during proof jwt parsing. aqhabqhs");
         }
 
         if (proofJwtHasNonceClaim != hasNonceEndpoint) {

--- a/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/VCIssuanceUtil.java
@@ -42,7 +42,7 @@ public class VCIssuanceUtil {
             }
         }
         catch (ParseException e) {
-            throw new CertifyException(VCIErrorConstants.INVALID_CREDENTIAL_REQUEST, "Error encountered during proof jwt parsing. aqhabqhs");
+            throw new CertifyException(VCIErrorConstants.INVALID_CREDENTIAL_REQUEST, "Error encountered during proof jwt parsing.");
         }
 
         if (proofJwtHasNonceClaim != hasNonceEndpoint) {

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
@@ -40,6 +40,7 @@ public class CredentialStatusServiceImplTest {
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        ReflectionTestUtils.setField(credentialStatusService, "allowedCredentialStatusPurposes", List.of());
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
@@ -4,8 +4,10 @@ import io.mosip.certify.core.dto.CredentialStatusResponse;
 import io.mosip.certify.core.dto.UpdateCredentialStatusRequest;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.entity.CredentialStatusTransaction;
+import io.mosip.certify.entity.Ledger;
 import io.mosip.certify.entity.StatusListCredential;
 import io.mosip.certify.repository.CredentialStatusTransactionRepository;
+import io.mosip.certify.repository.LedgerRepository;
 import io.mosip.certify.repository.StatusListCredentialRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,12 +26,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CredentialStatusServiceImplTest {
+public class    CredentialStatusServiceImplTest {
     @Mock
     private CredentialStatusTransactionRepository credentialStatusTransactionRepository;
 
     @Mock
     private StatusListCredentialRepository statusListCredentialRepository;
+
+    @Mock
+    private LedgerRepository ledgerRepository;
 
     @InjectMocks
     private CredentialStatusServiceImpl credentialStatusService;
@@ -37,6 +42,7 @@ public class CredentialStatusServiceImplTest {
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        when(ledgerRepository.findByCredentialId(any())).thenReturn(Optional.of(new Ledger()));
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
@@ -4,10 +4,8 @@ import io.mosip.certify.core.dto.CredentialStatusResponse;
 import io.mosip.certify.core.dto.UpdateCredentialStatusRequest;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.entity.CredentialStatusTransaction;
-import io.mosip.certify.entity.Ledger;
 import io.mosip.certify.entity.StatusListCredential;
 import io.mosip.certify.repository.CredentialStatusTransactionRepository;
-import io.mosip.certify.repository.LedgerRepository;
 import io.mosip.certify.repository.StatusListCredentialRepository;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,7 +14,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.Assert.assertNotNull;
@@ -26,15 +26,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class    CredentialStatusServiceImplTest {
+public class CredentialStatusServiceImplTest {
+
     @Mock
     private CredentialStatusTransactionRepository credentialStatusTransactionRepository;
 
     @Mock
     private StatusListCredentialRepository statusListCredentialRepository;
-
-    @Mock
-    private LedgerRepository ledgerRepository;
 
     @InjectMocks
     private CredentialStatusServiceImpl credentialStatusService;
@@ -42,14 +40,28 @@ public class    CredentialStatusServiceImplTest {
     @Before
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        when(ledgerRepository.findByCredentialId(any())).thenReturn(Optional.of(new Ledger()));
+    }
+
+    @Test
+    public void updateCredentialStatusV2_InvalidStatusPurpose_ThrowsException() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+        request.getCredentialStatus().setStatusPurpose("deactivate");
+        ReflectionTestUtils.setField(credentialStatusService, "allowedCredentialStatusPurposes", List.of("revocation"));
+
+        CertifyException exception = assertThrows(CertifyException.class, () -> {
+            credentialStatusService.updateCredentialStatus(request);
+        });
+
+        assertEquals("invalid_status_purpose", exception.getErrorCode());
+        assertEquals("Invalid credential status purpose. Allowed values are: [revocation]", exception.getMessage());
     }
 
     @Test
     public void updateCredentialStatusV2_StatusIdMismatch_ThrowsException() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
-        request.getCredentialStatus().setId("https://example.com/status-list/abc#12345"); // Mismatched ID
+        request.getCredentialStatus().setId("https://example.com/status-list/abc#12345");
 
         CertifyException exception = assertThrows(CertifyException.class, () -> {
             credentialStatusService.updateCredentialStatus(request);
@@ -75,25 +87,6 @@ public class    CredentialStatusServiceImplTest {
     }
 
     @Test
-    public void updateCredentialStatusV2_NullStatusPurpose_UsesStatusListCredentialPurpose() {
-        String statusListCredential = "https://example.com/status-list/xyz#87823";
-        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
-        request.getCredentialStatus().setStatusPurpose(null); // Null status purpose
-
-        StatusListCredential mockStatusListCredential = new StatusListCredential();
-        mockStatusListCredential.setStatusPurpose("revocation");
-
-        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
-        when(credentialStatusTransactionRepository.save(any(CredentialStatusTransaction.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        CredentialStatusResponse response = credentialStatusService.updateCredentialStatus(request);
-
-        assertNotNull(response);
-        assertEquals("revocation", response.getStatusPurpose());
-    }
-
-    @Test
     public void updateCredentialStatusV2_ValidRequest_ReturnsResponse() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
@@ -115,7 +108,7 @@ public class    CredentialStatusServiceImplTest {
 
     @Test
     public void updateCredentialStatusV2_NullStatusListCredential_ThrowsException() {
-        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(null); // Null StatusListCredential
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(null);
 
         CertifyException exception = assertThrows(CertifyException.class, () -> {
             credentialStatusService.updateCredentialStatus(request);
@@ -129,7 +122,7 @@ public class    CredentialStatusServiceImplTest {
     public void updateCredentialStatusV2_NullStatusListIndex_ThrowsException() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
-        request.getCredentialStatus().setStatusListIndex(null); // Null StatusListIndex
+        request.getCredentialStatus().setStatusListIndex(null);
 
         CertifyException exception = assertThrows(CertifyException.class, () -> {
             credentialStatusService.updateCredentialStatus(request);
@@ -137,25 +130,6 @@ public class    CredentialStatusServiceImplTest {
 
         assertEquals("status_list_not_found_for_the_given_id", exception.getErrorCode());
         assertEquals("Status List Credential not found for ID: https://example.com/status-list/xyz#87823", exception.getMessage());
-    }
-
-    @Test
-    public void updateCredentialStatusV2_EmptyStatusPurpose_UsesStatusListCredentialPurpose() {
-        String statusListCredential = "https://example.com/status-list/xyz#87823";
-        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
-        request.getCredentialStatus().setStatusPurpose(""); // Empty StatusPurpose
-
-        StatusListCredential mockStatusListCredential = new StatusListCredential();
-        mockStatusListCredential.setStatusPurpose("revocation");
-
-        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
-        when(credentialStatusTransactionRepository.save(any(CredentialStatusTransaction.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        CredentialStatusResponse response = credentialStatusService.updateCredentialStatus(request);
-
-        assertNotNull(response);
-        assertEquals("revocation", response.getStatusPurpose());
     }
 
     @Test
@@ -181,7 +155,7 @@ public class    CredentialStatusServiceImplTest {
 
         UpdateCredentialStatusRequest request = new UpdateCredentialStatusRequest();
         request.setCredentialStatus(statusDto);
-        request.setStatus(true); // Mark as revoked
+        request.setStatus(true);
 
         return request;
     }

--- a/certify-service/src/test/java/io/mosip/certify/services/VCIssuanceServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/VCIssuanceServiceImplTest.java
@@ -474,6 +474,35 @@ public class VCIssuanceServiceImplTest {
     }
 
     @Test
+    public void getCredential_UnparseableProofJwt_ThrowsInvalidCredentialRequest() {
+        request = new CredentialRequest();
+        request.setCredentialConfigId("test-credential-id-ldp");
+        request.setProofs(Map.of(ProofType.JWT, List.of("djedneujdnw")));
+
+        when(parsedAccessToken.isActive()).thenReturn(true);
+        when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
+        when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
+
+        CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
+        assertEquals(VCIErrorConstants.INVALID_CREDENTIAL_REQUEST, ex.getErrorCode());
+    }
+
+    @Test
+    public void getCredential_UnparseableProofJwtWithoutNonceEndpoint_ThrowsInvalidCredentialRequest() {
+        request = new CredentialRequest();
+        request.setCredentialConfigId("test-credential-id-ldp");
+        request.setProofs(Map.of(ProofType.JWT, List.of("notavalidjwt")));
+        mockGlobalCredentialIssuerMetadataDTO.setNonceEndpoint(null);
+
+        when(parsedAccessToken.isActive()).thenReturn(true);
+        when(parsedAccessToken.getClaims()).thenReturn(claimsFromAccessToken);
+        when(proofValidatorFactory.getProofValidator(anyString())).thenReturn(proofValidator);
+
+        CertifyException ex = assertThrows(CertifyException.class, () -> issuanceService.getCredential(request));
+        assertEquals(VCIErrorConstants.INVALID_CREDENTIAL_REQUEST, ex.getErrorCode());
+    }
+
+    @Test
     public void getCredential_NotAuthenticated_ThrowsException() throws Exception {
         request = createValidCredentialRequest(VCFormats.LDP_VC);
         when(parsedAccessToken.isActive()).thenReturn(false); // Token not active


### PR DESCRIPTION
## Description 

#878 

- added proper error messages for negative scenarios as mentioned in the test reports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential status updates now validate `statusPurpose` (required and restricted to an allowlist when configured).
  * Requests now ignore unknown JSON properties for improved resiliency.
* **Bug Fixes**
  * Improved HTTP error handling: unreadable messages now return `BAD_REQUEST`.
  * Missing credentials now return `NOT_FOUND` with the correct error code/message.
  * More robust proof/key decoding and clearer handling for invalid/unparseable credential requests.
* **Tests**
  * Extended coverage for invalid/unparseable proof JWT scenarios in credential issuance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->