### PR TITLE
INJICERT-1323: Add support for multiple SVG rendering templates

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/dto/RenderingTemplateDTO.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/RenderingTemplateDTO.java
@@ -11,6 +11,8 @@ public class RenderingTemplateDTO implements Serializable {
 
     private String id;
     private String template;
+    private String language;
+    private String side;
     private LocalDateTime createdTimes;
     private LocalDateTime updatedTimes;
 }

--- a/certify-core/src/main/java/io/mosip/certify/core/spi/RenderingTemplateService.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/spi/RenderingTemplateService.java
@@ -7,6 +7,9 @@ package io.mosip.certify.core.spi;
 
 import io.mosip.certify.core.dto.RenderingTemplateDTO;
 
+import java.util.List;
+
 public interface RenderingTemplateService {
     RenderingTemplateDTO getTemplate(String id);
+    List<RenderingTemplateDTO> getAllTemplates(String credentialConfigKeyId);
 }

--- a/certify-service/src/main/java/io/mosip/certify/entity/RenderingTemplate.java
+++ b/certify-service/src/main/java/io/mosip/certify/entity/RenderingTemplate.java
@@ -27,6 +27,15 @@ public class RenderingTemplate {
     @Column(name = "template")
     private String template;
 
+    @Column(name = "language")
+    private String language;
+
+    @Column(name = "side")
+    private String side;
+
+    @Column(name = "credential_config_key_id")
+    private String credentialConfigKeyId;
+
     @Column(name = "cr_dtimes")
     private LocalDateTime createdtimes;
 

--- a/certify-service/src/main/java/io/mosip/certify/repository/RenderingTemplateRepository.java
+++ b/certify-service/src/main/java/io/mosip/certify/repository/RenderingTemplateRepository.java
@@ -8,5 +8,8 @@ package io.mosip.certify.repository;
 import io.mosip.certify.entity.RenderingTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RenderingTemplateRepository extends JpaRepository<RenderingTemplate, String> {
+    List<RenderingTemplate> findByCredentialConfigKeyId(String credentialConfigKeyId);
 }

--- a/certify-service/src/main/java/io/mosip/certify/services/RenderingTemplateServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/RenderingTemplateServiceImpl.java
@@ -5,7 +5,9 @@
  */
 package io.mosip.certify.services;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
@@ -30,12 +32,24 @@ public class RenderingTemplateServiceImpl implements RenderingTemplateService {
     public RenderingTemplateDTO getTemplate(String id) {
         Optional<RenderingTemplate> optional = renderTemplateRepository.findById(id);
         RenderingTemplate renderingTemplate = optional.orElseThrow(() -> new RenderingTemplateException(ErrorConstants.INVALID_TEMPLATE_ID));
-        RenderingTemplateDTO renderingTemplateDTO = new RenderingTemplateDTO();
-        renderingTemplateDTO.setId(renderingTemplate.getId());
-        renderingTemplateDTO.setTemplate(renderingTemplate.getTemplate());
-        renderingTemplateDTO.setCreatedTimes(renderingTemplate.getCreatedtimes());
-        renderingTemplateDTO.setUpdatedTimes(renderingTemplate.getUpdatedtimes());
+        return toDTO(renderingTemplate);
+    }
 
-        return renderingTemplateDTO;
+    @Override
+    @Cacheable(cacheNames="renderTemplates", key="#credentialConfigKeyId")
+    public List<RenderingTemplateDTO> getAllTemplates(String credentialConfigKeyId) {
+        List<RenderingTemplate> templates = renderTemplateRepository.findByCredentialConfigKeyId(credentialConfigKeyId);
+        return templates.stream().map(this::toDTO).collect(Collectors.toList());
+    }
+
+    private RenderingTemplateDTO toDTO(RenderingTemplate renderingTemplate) {
+        RenderingTemplateDTO dto = new RenderingTemplateDTO();
+        dto.setId(renderingTemplate.getId());
+        dto.setTemplate(renderingTemplate.getTemplate());
+        dto.setLanguage(renderingTemplate.getLanguage());
+        dto.setSide(renderingTemplate.getSide());
+        dto.setCreatedTimes(renderingTemplate.getCreatedtimes());
+        dto.setUpdatedTimes(renderingTemplate.getUpdatedtimes());
+        return dto;
     }
 }

--- a/certify-service/src/main/java/io/mosip/certify/vcformatters/VelocityTemplatingEngineImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/vcformatters/VelocityTemplatingEngineImpl.java
@@ -228,13 +228,33 @@ public class VelocityTemplatingEngineImpl implements VCFormatter {
         updatedTemplateParams.put("_esc", new EscapeTool());
         // add the issuer value
         updatedTemplateParams.put("_issuer", issuer);
-        if (updatedTemplateParams.containsKey(Constants.RENDERING_TEMPLATE_ID) && templateName.contains(VCDM2Constants.URL)) {
+        if (templateName.contains(VCDM2Constants.URL)) {
             try {
-                updatedTemplateParams.put("_renderMethodSVGdigest",
-                        CredentialUtils.getDigestMultibase(renderingTemplateService.getTemplate(
-                                (String) updatedTemplateParams.get(Constants.RENDERING_TEMPLATE_ID)).getTemplate()));
+                CredentialConfig credentialConfig = getCachedCredentialConfig(templateName);
+                String credConfigKeyId = credentialConfig.getCredentialConfigKeyId();
+                List<io.mosip.certify.core.dto.RenderingTemplateDTO> allTemplates =
+                        renderingTemplateService.getAllTemplates(credConfigKeyId);
+                if (!allTemplates.isEmpty()) {
+                    List<Map<String, String>> renderMethods = new ArrayList<>();
+                    for (io.mosip.certify.core.dto.RenderingTemplateDTO t : allTemplates) {
+                        Map<String, String> entry = new HashMap<>();
+                        entry.put("id", t.getId());
+                        entry.put("digest", CredentialUtils.getDigestMultibase(t.getTemplate()));
+                        entry.put("name", t.getLanguage() + "-" + t.getSide());
+                        renderMethods.add(entry);
+                    }
+                    updatedTemplateParams.put("_renderMethods", renderMethods);
+                    // Backward compatibility: keep single digest for old-style Velocity templates
+                    updatedTemplateParams.put("_renderMethodSVGdigest",
+                            CredentialUtils.getDigestMultibase(allTemplates.get(0).getTemplate()));
+                } else if (updatedTemplateParams.containsKey(Constants.RENDERING_TEMPLATE_ID)) {
+                    // Fallback to legacy single rendering-template-id property
+                    updatedTemplateParams.put("_renderMethodSVGdigest",
+                            CredentialUtils.getDigestMultibase(renderingTemplateService.getTemplate(
+                                    (String) updatedTemplateParams.get(Constants.RENDERING_TEMPLATE_ID)).getTemplate()));
+                }
             } catch (RenderingTemplateException e) {
-                log.error("Template: " + updatedTemplateParams.get(Constants.RENDERING_TEMPLATE_ID) + " not available in DB", e);
+                log.error("Rendering template not available in DB for template: {}", templateName, e);
             }
         }
         VelocityContext context = new VelocityContext(updatedTemplateParams);

--- a/certify-service/src/test/java/io/mosip/certify/services/RenderingTemplateServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/RenderingTemplateServiceImplTest.java
@@ -1,6 +1,7 @@
 package io.mosip.certify.services;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Assert;
@@ -55,6 +56,57 @@ public class RenderingTemplateServiceImplTest {
             renderingTemplateService.getTemplate("fake-id");
         });
         Assert.assertEquals(ErrorConstants.INVALID_TEMPLATE_ID, templateException.getErrorCode());
+    }
+
+    @Test
+    public void getAllTemplates_withValidCredentialConfigKeyId_returnsAllTemplates() {
+        RenderingTemplate template1 = new RenderingTemplate();
+        template1.setId("tmpl-en-front");
+        template1.setTemplate("<svg>front-en</svg>");
+        template1.setLanguage("en");
+        template1.setSide("front");
+        template1.setCredentialConfigKeyId("FarmerCredential_VCDM2.0");
+        template1.setCreatedtimes(LocalDateTime.now());
+
+        RenderingTemplate template2 = new RenderingTemplate();
+        template2.setId("tmpl-en-back");
+        template2.setTemplate("<svg>back-en</svg>");
+        template2.setLanguage("en");
+        template2.setSide("back");
+        template2.setCredentialConfigKeyId("FarmerCredential_VCDM2.0");
+        template2.setCreatedtimes(LocalDateTime.now());
+
+        RenderingTemplate template3 = new RenderingTemplate();
+        template3.setId("tmpl-hi-front");
+        template3.setTemplate("<svg>front-hi</svg>");
+        template3.setLanguage("hi");
+        template3.setSide("front");
+        template3.setCredentialConfigKeyId("FarmerCredential_VCDM2.0");
+        template3.setCreatedtimes(LocalDateTime.now());
+
+        Mockito.when(svgRenderTemplateRepository.findByCredentialConfigKeyId("FarmerCredential_VCDM2.0"))
+                .thenReturn(List.of(template1, template2, template3));
+
+        List<RenderingTemplateDTO> result = renderingTemplateService.getAllTemplates("FarmerCredential_VCDM2.0");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(3, result.size());
+        Assert.assertEquals("tmpl-en-front", result.get(0).getId());
+        Assert.assertEquals("en", result.get(0).getLanguage());
+        Assert.assertEquals("front", result.get(0).getSide());
+        Assert.assertEquals("tmpl-en-back", result.get(1).getId());
+        Assert.assertEquals("tmpl-hi-front", result.get(2).getId());
+    }
+
+    @Test
+    public void getAllTemplates_withNoMatchingKey_returnsEmptyList() {
+        Mockito.when(svgRenderTemplateRepository.findByCredentialConfigKeyId("unknown-key"))
+                .thenReturn(List.of());
+
+        List<RenderingTemplateDTO> result = renderingTemplateService.getAllTemplates("unknown-key");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.isEmpty());
     }
 
 }

--- a/certify-service/src/test/resources/schema.sql
+++ b/certify-service/src/test/resources/schema.sql
@@ -72,6 +72,9 @@ CREATE TABLE IF NOT EXISTS ca_cert_store(
 CREATE TABLE IF NOT EXISTS rendering_template (
     id VARCHAR(128) NOT NULL,
     template VARCHAR NOT NULL,
+    language VARCHAR(10) DEFAULT 'en',
+    side VARCHAR(10) DEFAULT 'front',
+    credential_config_key_id VARCHAR(255),
     cr_dtimes timestamp NOT NULL,
     upd_dtimes timestamp,
     CONSTRAINT pk_rendertmp_id PRIMARY KEY (id)

--- a/certify-service/src/test/resources/schema.sql
+++ b/certify-service/src/test/resources/schema.sql
@@ -110,11 +110,6 @@ CREATE TABLE IF NOT EXISTS credential_config (
     CONSTRAINT pk_config_id PRIMARY KEY (context, credential_type, credential_format)
 );
 
-ALTER TABLE rendering_template
-    ADD CONSTRAINT fk_rendering_template_credential_config
-    FOREIGN KEY (credential_config_key_id)
-    REFERENCES credential_config(credential_config_key_id)
-    ON DELETE SET NULL;
 
 CREATE INDEX IF NOT EXISTS idx_rendering_template_credential_config_key_id
     ON rendering_template(credential_config_key_id);

--- a/certify-service/src/test/resources/schema.sql
+++ b/certify-service/src/test/resources/schema.sql
@@ -77,11 +77,8 @@ CREATE TABLE IF NOT EXISTS rendering_template (
     credential_config_key_id VARCHAR(2048),
     cr_dtimes timestamp NOT NULL,
     upd_dtimes timestamp,
-    CONSTRAINT pk_rendertmp_id PRIMARY KEY (id),
-    CONSTRAINT fk_rendering_template_credential_config FOREIGN KEY (credential_config_key_id) REFERENCES credential_config(credential_config_key_id) ON DELETE SET NULL
+    CONSTRAINT pk_rendertmp_id PRIMARY KEY (id)
 );
-
-CREATE INDEX IF NOT EXISTS idx_rendering_template_credential_config_key_id ON rendering_template(credential_config_key_id);
 
 -- Changed all `JSONB` and `TEXT[]` types to VARCHAR to make it work with H2 database
 CREATE TABLE IF NOT EXISTS credential_config (
@@ -112,3 +109,13 @@ CREATE TABLE IF NOT EXISTS credential_config (
     upd_dtimes TIMESTAMP,
     CONSTRAINT pk_config_id PRIMARY KEY (context, credential_type, credential_format)
 );
+
+ALTER TABLE rendering_template
+    ADD CONSTRAINT fk_rendering_template_credential_config
+    FOREIGN KEY (credential_config_key_id)
+    REFERENCES credential_config(credential_config_key_id)
+    ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_rendering_template_credential_config_key_id
+    ON rendering_template(credential_config_key_id);
+

--- a/certify-service/src/test/resources/schema.sql
+++ b/certify-service/src/test/resources/schema.sql
@@ -74,11 +74,14 @@ CREATE TABLE IF NOT EXISTS rendering_template (
     template VARCHAR NOT NULL,
     language VARCHAR(10) DEFAULT 'en',
     side VARCHAR(10) DEFAULT 'front',
-    credential_config_key_id VARCHAR(255),
+    credential_config_key_id VARCHAR(2048),
     cr_dtimes timestamp NOT NULL,
     upd_dtimes timestamp,
-    CONSTRAINT pk_rendertmp_id PRIMARY KEY (id)
+    CONSTRAINT pk_rendertmp_id PRIMARY KEY (id),
+    CONSTRAINT fk_rendering_template_credential_config FOREIGN KEY (credential_config_key_id) REFERENCES credential_config(credential_config_key_id) ON DELETE SET NULL
 );
+
+CREATE INDEX IF NOT EXISTS idx_rendering_template_credential_config_key_id ON rendering_template(credential_config_key_id);
 
 -- Changed all `JSONB` and `TEXT[]` types to VARCHAR to make it work with H2 database
 CREATE TABLE IF NOT EXISTS credential_config (

--- a/db_scripts/inji_certify/ddl/certify-rendering_template_alter.sql
+++ b/db_scripts/inji_certify/ddl/certify-rendering_template_alter.sql
@@ -1,0 +1,20 @@
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this
+-- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+-- -------------------------------------------------------------------------------------------------
+-- Database Name: inji_certify
+-- Table Name : rendering_template
+-- Purpose    : Alter rendering_template to support multiple SVG templates per credential type
+--
+-- Modified Date        Modified By         Comments / Remarks
+-- ------------------------------------------------------------------------------------------
+-- ------------------------------------------------------------------------------------------
+
+ALTER TABLE rendering_template
+    ADD COLUMN IF NOT EXISTS language VARCHAR(10) DEFAULT 'en',
+    ADD COLUMN IF NOT EXISTS side VARCHAR(10) DEFAULT 'front',
+    ADD COLUMN IF NOT EXISTS credential_config_key_id VARCHAR(2048);
+
+COMMENT ON COLUMN rendering_template.language IS 'Language code for the SVG template (e.g. en, fr, ar).';
+COMMENT ON COLUMN rendering_template.side IS 'Side of the credential the SVG represents: front or back.';
+COMMENT ON COLUMN rendering_template.credential_config_key_id IS 'References credential_config.credential_config_key_id to link SVG templates to a credential type.';

--- a/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_rollback.sql
+++ b/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_rollback.sql
@@ -68,9 +68,9 @@ WHERE proof_types_supported #> '{jwt,proof_signing_alg_values_supported}' IS NOT
 DROP INDEX IF EXISTS certify.idx_rendering_template_credential_config_key_id;
 
 ALTER TABLE certify.rendering_template
-DROP CONSTRAINT IF EXISTS fk_rendering_template_credential_config;
+    DROP CONSTRAINT IF EXISTS fk_rendering_template_credential_config;
 
 ALTER TABLE certify.rendering_template
-DROP COLUMN IF EXISTS credential_config_key_id,
+    DROP COLUMN IF EXISTS credential_config_key_id,
     DROP COLUMN IF EXISTS side,
     DROP COLUMN IF EXISTS language;

--- a/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_rollback.sql
+++ b/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_rollback.sql
@@ -64,3 +64,13 @@ WHERE proof_types_supported #> '{jwt,proof_signing_alg_values_supported}' IS NOT
       FROM jsonb_array_elements(proof_types_supported #> '{jwt,proof_signing_alg_values_supported}') AS alg
       WHERE alg = '"EdDSA"'::jsonb
   );
+
+DROP INDEX IF EXISTS certify.idx_rendering_template_credential_config_key_id;
+
+ALTER TABLE certify.rendering_template
+DROP CONSTRAINT IF EXISTS fk_rendering_template_credential_config;
+
+ALTER TABLE certify.rendering_template
+DROP COLUMN IF EXISTS credential_config_key_id,
+    DROP COLUMN IF EXISTS side,
+    DROP COLUMN IF EXISTS language;

--- a/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_upgrade.sql
+++ b/db_upgrade_script/inji_certify/sql/0.14.0_to_1.0.0_upgrade.sql
@@ -121,3 +121,14 @@ WHERE proof_types_supported #> '{jwt,proof_signing_alg_values_supported}' IS NOT
       FROM jsonb_array_elements(proof_types_supported #> '{jwt,proof_signing_alg_values_supported}') AS alg
       WHERE alg = '"Ed25519"'::jsonb
   );
+ALTER TABLE certify.rendering_template
+    ADD COLUMN IF NOT EXISTS language VARCHAR(10) DEFAULT 'en',
+    ADD COLUMN IF NOT EXISTS side VARCHAR(10) DEFAULT 'front',
+    ADD COLUMN IF NOT EXISTS credential_config_key_id VARCHAR(2048),
+    ADD CONSTRAINT fk_rendering_template_credential_config
+    FOREIGN KEY (credential_config_key_id)
+    REFERENCES certify.credential_config(credential_config_key_id)
+    ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_rendering_template_credential_config_key_id
+    ON certify.rendering_template(credential_config_key_id);


### PR DESCRIPTION
- Adds support for rendering multiple SVG templates per credential type by introducing language, side, and credential_config_key_id columns in the rendering_template table. The VC template's renderMethod is now dynamically populated using a Velocity #foreach loop over all templates linked to a credential config, replacing the previously hardcoded single entry.
- Added corresponding unit test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended template system to support language and side attributes
  * Added ability to retrieve all templates for a credential configuration
  * Enhanced rendering engine to support multiple templates with digest metadata

* **Tests**
  * Added test coverage for template retrieval functionality

* **Chores**
  * Updated database schema to support new template attributes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->