### PR TITLE
INJICERT-908 Updated docker-compose setup Readme as per latest changes

### DIFF
--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -39,7 +39,7 @@ Create the following directory structure in your local codebase before proceedin
 ```
 docker-compose-injistack/
 ├── data/
-│   └── CERTIFY_PKCS12/(p12 file generated at runtime)
+│   └── CERTIFY_PKCS12/ (p12 file generated at runtime)
 ├── certs/
 │   └── oidckeystore.p12 (to be obtained during onboarding of mimoto to esignet)
 ├── loader_path/
@@ -47,12 +47,20 @@ docker-compose-injistack/
 ├── config/ (default setup should work as is for csvplugin, any other config changes user can make as per their setup)
 │   ├── certify-default.properties
 │   ├── certify-csvdp-farmer.properties
+│   ├── certify-mock-mdl.properties
+│   ├── farmer_identity_data.csv
+│   ├── mimoto-bootstrap.properties
 │   ├── mimoto-default.properties
 │   ├── mimoto-issuers-config.json
 │   ├── mimoto-trusted-verifiers.json
+│   ├── vp_request_config.json
 │   └── credential-template.html
+├── context/
 ├── nginx.conf
+├── certify-nginx.conf
 ├── certify_init.sql
+├── mimoto_init.sql
+├── verify_init.sql
 └── docker-compose.yml
 ```
 
@@ -187,7 +195,7 @@ The following services will be available:
 - Certify Nginx: `localhost:8091`
 - Mimoto Service: `localhost:8099`
 - Inji Web: `localhost:3004`
-- Inji Verify: `localhost:8095`
+- Inji Verify: `localhost:8095` (available only if the `verify-service` is uncommented in `docker-compose.yml`; see [Verify Service](#verify-service))
 
 ## Using the Application
 

--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -55,7 +55,7 @@ docker-compose-injistack/
 │   ├── mimoto-trusted-verifiers.json
 │   ├── vp_request_config.json
 │   └── credential-template.html
-├── context/
+├── context/           (user-supplied JSON-LD context files for credential types, e.g. farmer.json)
 ├── nginx.conf
 ├── certify-nginx.conf
 ├── certify_init.sql


### PR DESCRIPTION
## Description

#908 

- I have updated the docker-compose setup readme file according to the latest changes
- File path: `docker-compose/docker-compose-injistack/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Docker Compose setup documentation with detailed directory structure information, including newly documented runtime-generated directories and configuration files.
  * Clarified service endpoint availability for the Inji Verify service based on its configuration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->