### PR TITLE
INJICERT-1162 added validations for invalid sd_claims

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -56,6 +56,7 @@ public class ErrorConstants {
     public static final String STATUS_ID_MISMATCH = "status_id_mismatch";
     public static final String JSON_PROCESSING_ERROR = "json_processing_error";
     public static final String SD_CLAIMS_PARSE_ERROR = "sd_claims_parse_error";
+    public static final String INVALID_SD_CLAIMS = "invalid_sd_claims";
     public static final String MULTIPLE_STATUS_PURPOSES_NOT_SUPPORTED = "multiple_status_purposes_not_supported";
     public static final String INVALID_STATUS_PURPOSE = "invalid_status_purpose";
     public static final String CREDENTIAL_TEMPLATE_REQUIRED = "credential_template_required";

--- a/certify-service/src/main/java/io/mosip/certify/credential/SDJWT.java
+++ b/certify-service/src/main/java/io/mosip/certify/credential/SDJWT.java
@@ -76,12 +76,19 @@ public class SDJWT extends Credential{
         PlainHeader header = new PlainHeader();
         JsonNode node;
         String currentPath = "$";
+        
 
         String templatedJSON = super.createCredential(updatedTemplateParams, templateName);
         List<String> sdPaths = super.vcFormatter.getSelectiveDisclosureInfo(templateName);   
         try {
             
             node = objectMapper.readTree(templatedJSON);
+            List<String> invalidSdPaths = SDJsonUtils.findInvalidSdPaths(node, sdPaths);
+            if (!invalidSdPaths.isEmpty()) {
+                log.error("Invalid sd_claims paths not found in VC data: {}", invalidSdPaths);
+                throw new CertifyException(ErrorConstants.INVALID_SD_CLAIMS,
+                        "sd_claims contains paths that do not exist in the credential data: " + invalidSdPaths);
+            }
             SDJsonUtils.constructSDPayload(node, sdObjectBuilder, disclosures, sdPaths, currentPath);
             Map<String,Object>  sdClaims = sdObjectBuilder.build();
             JWTClaimsSet claimsSet = JWTClaimsSet.parse(sdClaims);

--- a/certify-service/src/main/java/io/mosip/certify/utils/SDJsonUtils.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/SDJsonUtils.java
@@ -222,6 +222,71 @@ public class SDJsonUtils {
     }
 
     /**
+     * Validates that every sd_claims path exists in the given JSON node.
+     *
+     * @param root    The root JsonNode built from the templated VC JSON.
+     * @param sdPaths The configured sd_claims paths (e.g. ["$.sub", "$.address[*].city"]).
+     * @return A list of paths that could not be resolved in the JSON (empty means all valid).
+     */
+    public static List<String> findInvalidSdPaths(JsonNode root, List<String> sdPaths) {
+        List<String> invalidPaths = new ArrayList<>();
+        for (String sdPath : sdPaths) {
+            if (!existsInJson(root, sdPath.trim())) {
+                invalidPaths.add(sdPath);
+            }
+        }
+        return invalidPaths;
+    }
+
+    /**
+     * Returns true when {@code sdPath} resolves to at least one node inside {@code root}.
+     * Supports simple fields, object traversal, and array wildcards ([*]) or indices ([n]).
+     */
+    private static boolean existsInJson(JsonNode root, String sdPath) {
+        String path = sdPath;
+        if (path.startsWith("$.")) {
+            path = path.substring(2);
+        } else if (path.startsWith("$")) {
+            path = path.substring(1);
+        }
+        if (path.isEmpty()) return true;
+
+        List<JsonNode> current = new ArrayList<>();
+        current.add(root);
+
+        for (String segment : path.split("\\.")) {
+            List<JsonNode> next = new ArrayList<>();
+            for (JsonNode node : current) {
+                if (segment.contains("[")) {
+                    int bracketStart = segment.indexOf('[');
+                    String fieldName = segment.substring(0, bracketStart);
+                    String indexStr = segment.substring(bracketStart + 1, segment.indexOf(']'));
+
+                    JsonNode arrayNode = fieldName.isEmpty() ? node : node.get(fieldName);
+                    if (arrayNode == null || !arrayNode.isArray()) continue;
+
+                    if ("*".equals(indexStr)) {
+                        arrayNode.forEach(next::add);
+                    } else {
+                        try {
+                            int idx = Integer.parseInt(indexStr);
+                            if (idx < arrayNode.size()) next.add(arrayNode.get(idx));
+                        } catch (NumberFormatException e) {
+                            log.warn("Unrecognised array index in sd_claims path segment: {}", segment);
+                        }
+                    }
+                } else {
+                    JsonNode child = node.get(segment);
+                    if (child != null && !child.isMissingNode()) next.add(child);
+                }
+            }
+            current = next;
+            if (current.isEmpty()) return false;
+        }
+        return true;
+    }
+
+    /**
      * Extracts the leaf node name from the given JSONPath string.
      *
      * @param jsonPath The JSONPath string (e.g., $.store.book[0].author)

--- a/certify-service/src/main/java/io/mosip/certify/utils/SDJsonUtils.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/SDJsonUtils.java
@@ -230,8 +230,16 @@ public class SDJsonUtils {
      */
     public static List<String> findInvalidSdPaths(JsonNode root, List<String> sdPaths) {
         List<String> invalidPaths = new ArrayList<>();
+        if (sdPaths == null) {
+            return invalidPaths;
+        }
         for (String sdPath : sdPaths) {
-            if (!existsInJson(root, sdPath.trim())) {
+            if (sdPath == null) {
+                invalidPaths.add(null);
+                continue;
+            }
+            String trimmed = sdPath.trim();
+            if (trimmed.isEmpty() || !existsInJson(root, trimmed)) {
                 invalidPaths.add(sdPath);
             }
         }
@@ -259,8 +267,12 @@ public class SDJsonUtils {
             for (JsonNode node : current) {
                 if (segment.contains("[")) {
                     int bracketStart = segment.indexOf('[');
+                    int bracketEnd = segment.indexOf(']');
+                    if (bracketEnd <= bracketStart) {
+                        return false;
+                    }
                     String fieldName = segment.substring(0, bracketStart);
-                    String indexStr = segment.substring(bracketStart + 1, segment.indexOf(']'));
+                    String indexStr = segment.substring(bracketStart + 1, bracketEnd);
 
                     JsonNode arrayNode = fieldName.isEmpty() ? node : node.get(fieldName);
                     if (arrayNode == null || !arrayNode.isArray()) continue;

--- a/certify-service/src/test/java/io/mosip/certify/credential/SDJWTTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/credential/SDJWTTest.java
@@ -1,7 +1,5 @@
 package io.mosip.certify.credential;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mosip.certify.api.dto.VCResult;
 import io.mosip.certify.core.constants.ErrorConstants;
@@ -36,8 +34,7 @@ public class SDJWTTest {
     @Mock
     private SignatureService mockSignatureService;
 
-    @Mock
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @InjectMocks
     private SDJWT sdjwt;
@@ -60,16 +57,14 @@ public class SDJWTTest {
     }
 
     @Test
-    public void testCreateCredential_WithValidInput_ReturnsSdJwt() throws JsonProcessingException {
+    public void testCreateCredential_WithValidInput_ReturnsSdJwt() {
         String mockTemplateName = "mockTemplate";
         Map<String, Object> templateParams = new HashMap<>();
 
         String templateJson = "{\"name\": \"John\", \"age\": 30}";
-        JsonNode mockJsonNode =  mock(JsonNode.class);
         when(mockFormatter.format(any(Map.class))).thenReturn(templateJson);
         when(mockFormatter.getSelectiveDisclosureInfo(mockTemplateName))
                 .thenReturn(Arrays.asList("$.name"));
-        when(objectMapper.readTree(templateJson)).thenReturn(mockJsonNode);
 
         String result = sdjwt.createCredential(templateParams, mockTemplateName);
 
@@ -78,13 +73,12 @@ public class SDJWTTest {
     }
 
     @Test
-    public void testCreateCredential_WithInvalidJson_ReturnsFallbackJwt() throws JsonProcessingException {
+    public void testCreateCredential_WithInvalidJson_ReturnsFallbackJwt() {
         String mockTemplateName = "badTemplate";
         Map<String, Object> templateParams = new HashMap<>();
 
         when(mockFormatter.format(any(Map.class))).thenReturn("{invalid json}");
         when(mockFormatter.getSelectiveDisclosureInfo(mockTemplateName)).thenReturn(Arrays.asList("$.invalid"));
-        when(objectMapper.readTree("{invalid json}")).thenThrow(new JsonProcessingException("Invalid JSON") {});
 
         CertifyException exception = assertThrows(CertifyException.class, () -> {
             sdjwt.createCredential(templateParams, mockTemplateName);
@@ -92,6 +86,23 @@ public class SDJWTTest {
 
         assertEquals(ErrorConstants.JSON_PROCESSING_ERROR, exception.getErrorCode());
         assertTrue(exception.getMessage().contains("Failed to process JSON during SD-JWT creation."));
+    }
+
+    @Test
+    public void testCreateCredential_WithInvalidSdClaimPaths_ThrowsCertifyException() {
+        String mockTemplateName = "mockTemplate";
+        Map<String, Object> templateParams = new HashMap<>();
+
+        // Template has plain string fields, but sdClaim paths expect arrays / non-existent fields
+        String templateJson = "{\"gender\": \"Male\", \"fullName\": \"John Doe\"}";
+        when(mockFormatter.format(any(Map.class))).thenReturn(templateJson);
+        when(mockFormatter.getSelectiveDisclosureInfo(mockTemplateName))
+                .thenReturn(Arrays.asList("$.gender[*].*", "$.contactDetails", "$.fullName[*].value"));
+
+        CertifyException exception = assertThrows(CertifyException.class, () ->
+                sdjwt.createCredential(templateParams, mockTemplateName));
+
+        assertEquals(ErrorConstants.INVALID_SD_CLAIMS, exception.getErrorCode());
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/utils/SDJsonUtilsTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/utils/SDJsonUtilsTest.java
@@ -192,6 +192,93 @@ public class SDJsonUtilsTest extends TestCase {
       assertTrue(mobilePhoneObject.containsKey("number"));
     }
 
+  // ── findInvalidSdPaths ────────────────────────────────────────────────────
+
+  public void testFindInvalidSdPaths_AllValidSimpleFields() {
+      ObjectNode root = JsonNodeFactory.instance.objectNode();
+      root.put("gender", "Male");
+      root.put("fullName", "John Doe");
+      root.put("dateOfBirth", "1990-01-01");
+
+      List<String> invalid = SDJsonUtils.findInvalidSdPaths(root,
+              Arrays.asList("$.gender", "$.fullName", "$.dateOfBirth"));
+      assertTrue("All simple field paths should be valid", invalid.isEmpty());
+  }
+
+  public void testFindInvalidSdPaths_NonExistentField() {
+      ObjectNode root = JsonNodeFactory.instance.objectNode();
+      root.put("gender", "Male");
+
+      List<String> invalid = SDJsonUtils.findInvalidSdPaths(root,
+              Arrays.asList("$.contactDetails"));
+      assertEquals(1, invalid.size());
+      assertEquals("$.contactDetails", invalid.get(0));
+  }
+
+  /**
+   * Reproduces INJICERT-1162: gender and fullName exist as plain strings in the
+   * template, but the sdClaim is configured with array-style paths ([*]).
+   * These paths must be reported as invalid.
+   */
+  public void testFindInvalidSdPaths_ArrayPathOnStringField() {
+      ObjectNode root = JsonNodeFactory.instance.objectNode();
+      root.put("gender", "Male");
+      root.put("fullName", "John Doe");
+      root.put("dateOfBirth", "1990-01-01");
+
+      List<String> invalid = SDJsonUtils.findInvalidSdPaths(root,
+              Arrays.asList("$.gender[*].*", "$.fullName[*].value", "$.dateOfBirth"));
+      assertEquals(2, invalid.size());
+      assertTrue(invalid.contains("$.gender[*].*"));
+      assertTrue(invalid.contains("$.fullName[*].value"));
+  }
+
+  public void testFindInvalidSdPaths_ValidArrayWildcardPath() {
+      ObjectNode root = JsonNodeFactory.instance.objectNode();
+      ArrayNode addresses = JsonNodeFactory.instance.arrayNode();
+      ObjectNode addr = JsonNodeFactory.instance.objectNode();
+      addr.put("city", "New York");
+      addresses.add(addr);
+      root.set("addresses", addresses);
+
+      List<String> invalid = SDJsonUtils.findInvalidSdPaths(root,
+              Arrays.asList("$.addresses[*].city"));
+      assertTrue("Valid array wildcard path should not be flagged", invalid.isEmpty());
+  }
+
+  public void testFindInvalidSdPaths_ValidSpecificIndexPath() {
+      ObjectNode root = JsonNodeFactory.instance.objectNode();
+      ArrayNode phones = JsonNodeFactory.instance.arrayNode();
+      phones.add("123-456");
+      root.set("phones", phones);
+
+      List<String> invalid = SDJsonUtils.findInvalidSdPaths(root,
+              Arrays.asList("$.phones[0]"));
+      assertTrue("Valid specific-index path should not be flagged", invalid.isEmpty());
+  }
+
+  public void testFindInvalidSdPaths_EmptySdPaths() {
+      ObjectNode root = JsonNodeFactory.instance.objectNode();
+      root.put("name", "John");
+
+      List<String> invalid = SDJsonUtils.findInvalidSdPaths(root, Arrays.asList());
+      assertTrue("Empty sdPaths list should return no invalid paths", invalid.isEmpty());
+  }
+
+  public void testFindInvalidSdPaths_MixedValidAndInvalid() {
+      ObjectNode root = JsonNodeFactory.instance.objectNode();
+      root.put("dateOfBirth", "1990-01-01");
+      root.put("region", "South");
+
+      List<String> invalid = SDJsonUtils.findInvalidSdPaths(root,
+              Arrays.asList("$.dateOfBirth", "$.contactDetails", "$.region", "$.identityDetails.*"));
+      assertEquals(2, invalid.size());
+      assertTrue(invalid.contains("$.contactDetails"));
+      assertTrue(invalid.contains("$.identityDetails.*"));
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+
   public void testConstructSDPayload_WildcardPatterns(){
     // Create the input JSONNode from the provided JSON
     ObjectNode node = JsonNodeFactory.instance.objectNode();


### PR DESCRIPTION
## Description

#711 

### Issue Identified
When invalid sd_claims values are passed in the VCT, the issuer currently proceeds to fetch the Verifiable Credential (VC) successfully, even though no disclosures are present.
This behavior is incorrect. The issuer should validate the sd_claims upfront and fail early when invalid or malformed values are detected.

### Steps to Reproduce
- Add a VCT containing random or invalid sd_claims keys.
- Use the same VCT to fetch a VC.

### Actual Behavior
- VC fetch succeeds.
- Returned VC contains no disclosures, indicating the claim names did not match the template.

### Expected Behavior
- The issuer should validate sd_claims against the template.
- Invalid claims should cause an error immediately.
- VC fetch should not proceed.

### Tests Added

- Have added test cases for the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to verify that all selective-disclosure claim paths configured for an SD-JWT exist in the input credential before SD-JWT generation.
  * If any paths are invalid or cannot be resolved, credential generation now stops and returns a clear `invalid_sd_claims` error instead of producing an incorrect SD-JWT.
* **Tests**
  * Expanded unit tests to cover valid/invalid selective-disclosure path scenarios and updated existing tests to use real JSON parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->