### PR TITLE
[KATTU-334] Update sonar workflow reference to develop

### DIFF
--- a/.github/workflows/push-trigger.yml
+++ b/.github/workflows/push-trigger.yml
@@ -169,7 +169,7 @@ jobs:
   sonar_analysis:
     needs: build-maven-inji-certify
     if: "${{  github.event_name != 'pull_request' }}"
-    uses: mosip/kattu/.github/workflows/maven-sonar-analysis.yml@dsd9685
+    uses: mosip/kattu/.github/workflows/maven-sonar-analysis.yml@develop
     with:
       SERVICE_LOCATION: ./
     secrets:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to reference the develop branch instead of a pinned commit hash for the Sonar analysis step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->