### PR TITLE
update docker image and pom

### DIFF
--- a/certify-service/pom.xml
+++ b/certify-service/pom.xml
@@ -252,7 +252,7 @@
         <dependency>
             <groupId>io.inji.verify</groupId>
             <artifactId>verify-service</artifactId>
-            <version>0.18.2-SNAPSHOT</version>
+            <version>0.18.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.inji</groupId>

--- a/docker-compose/docker-compose-injistack/docker-compose.yaml
+++ b/docker-compose/docker-compose-injistack/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "5433:5432"
 
   certify:
-    image: injistack/inji-certify-with-plugins:0.14.0
+    image: injistackdev/inji-certify-with-plugins:release-1.0.x
     user: root
     ports:
       - 8090:8090
@@ -60,7 +60,7 @@ services:
 
   mimoto-service:
     container_name: 'mimoto-service'
-    image: injistack/mimoto:0.21.0
+    image: injistackdev/mimoto:develop
     user: root
     ports:
       - '8099:8099'
@@ -90,7 +90,7 @@ services:
 
   inji-web:
     container_name: 'inji-web'
-    image: injistack/inji-web:0.16.0
+    image:  injistackdev/inji-web:develop
     ports:
       - '3004:3004'
     environment:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the verification service to the stable 0.18.2 release.
  * Updated the default Docker Compose setup to use the latest development builds of Certify, Mimoto, and Inji Web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->