### PR TITLE
fix: handle JSON parse exceptions gracefully in VCI issuance endpoint(#878)

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -175,7 +175,10 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
             } else if (cause instanceof JsonParseException) {
                 message = "Malformed JSON syntax error";
             } else if (cause instanceof JsonMappingException) {
-                message = "Invalid request structure";
+                JsonMappingException mappingEx = (JsonMappingException) cause;
+                String fieldName = mappingEx.getPath().isEmpty() ? "unknown"
+                    : mappingEx.getPath().get(mappingEx.getPath().size() - 1).getFieldName();
+                message = String.format("Invalid request structure for field '%s'", fieldName);
             }
 
             return new ResponseEntity<>(getVCErrorDto(INVALID_REQUEST, message), HttpStatus.BAD_REQUEST);

--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -169,6 +169,8 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
                 message = String.format("Unrecognized field '%s' in request", propEx.getPropertyName());
             } else if (cause instanceof InvalidFormatException) {
                 message = "Invalid field format in request";
+            } else if (cause instanceof JsonParseException) {
+                message = "Malformed JSON syntax error";
             } else if (cause instanceof JsonMappingException) {
                 message = "Invalid request structure";
             }

--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -168,7 +168,10 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
                     (UnrecognizedPropertyException) cause;
                 message = String.format("Unrecognized field '%s' in request", propEx.getPropertyName());
             } else if (cause instanceof InvalidFormatException) {
-                message = "Invalid field format in request";
+                InvalidFormatException formatEx = (InvalidFormatException) cause;
+                String fieldName = formatEx.getPath().isEmpty() ? "unknown"
+                    : formatEx.getPath().get(formatEx.getPath().size() - 1).getFieldName();
+                message = String.format("Invalid format for field '%s' in request", fieldName);
             } else if (cause instanceof JsonParseException) {
                 message = "Malformed JSON syntax error";
             } else if (cause instanceof JsonMappingException) {

--- a/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
+++ b/certify-service/src/main/java/io/mosip/certify/advice/ExceptionHandlerAdvice.java
@@ -36,6 +36,11 @@ import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -153,6 +158,23 @@ public class ExceptionHandlerAdvice extends ResponseEntityExceptionHandler imple
     }
 
     public ResponseEntity<VCError> handleVCIControllerExceptions(Exception ex, HttpServletRequest request) {
+        if(ex instanceof HttpMessageNotReadableException) {
+            String message = "Invalid JSON request body";
+            Throwable cause = ex.getCause();
+
+            // Provide more specific error based on the root cause
+            if (cause instanceof UnrecognizedPropertyException) {
+                UnrecognizedPropertyException propEx =
+                    (UnrecognizedPropertyException) cause;
+                message = String.format("Unrecognized field '%s' in request", propEx.getPropertyName());
+            } else if (cause instanceof InvalidFormatException) {
+                message = "Invalid field format in request";
+            } else if (cause instanceof JsonMappingException) {
+                message = "Invalid request structure";
+            }
+
+            return new ResponseEntity<>(getVCErrorDto(INVALID_REQUEST, message), HttpStatus.BAD_REQUEST);
+        }
         if(ex instanceof MethodArgumentNotValidException) {
             FieldError fieldError = ((MethodArgumentNotValidException) ex).getBindingResult().getFieldError();
             String message = fieldError != null ? fieldError.getDefaultMessage() : ex.getMessage();

--- a/certify-service/src/test/java/io/mosip/certify/advice/ExceptionHandlerAdviceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/advice/ExceptionHandlerAdviceTest.java
@@ -1,0 +1,87 @@
+package io.mosip.certify.advice;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import io.mosip.certify.core.dto.VCError;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+
+public class ExceptionHandlerAdviceTest {
+
+    private final ExceptionHandlerAdvice advice = new ExceptionHandlerAdvice();
+    private final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+
+    @Test
+    public void testHandleVCIControllerExceptions_UnrecognizedPropertyException() {
+        com.fasterxml.jackson.core.JsonParser parser = Mockito.mock(com.fasterxml.jackson.core.JsonParser.class);
+        Mockito.when(parser.getCurrentLocation()).thenReturn(com.fasterxml.jackson.core.JsonLocation.NA);
+        UnrecognizedPropertyException cause = UnrecognizedPropertyException.from(
+                parser, Object.class, "unrecognized_field", null
+        );
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("msg", cause, null);
+
+        ResponseEntity<VCError> response = advice.handleVCIControllerExceptions(ex, request);
+
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals("invalid_request", response.getBody().getError());
+        Assert.assertEquals("Unrecognized field 'unrecognized_field' in request", response.getBody().getError_description());
+    }
+
+    @Test
+    public void testHandleVCIControllerExceptions_InvalidFormatException() {
+        InvalidFormatException cause = InvalidFormatException.from(
+                null, "msg", "value", String.class
+        );
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("msg", cause, null);
+
+        ResponseEntity<VCError> response = advice.handleVCIControllerExceptions(ex, request);
+
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals("invalid_request", response.getBody().getError());
+        Assert.assertEquals("Invalid field format in request", response.getBody().getError_description());
+    }
+
+    @Test
+    public void testHandleVCIControllerExceptions_JsonParseException() {
+        JsonParseException cause = new JsonParseException(null, "msg");
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("msg", cause, null);
+
+        ResponseEntity<VCError> response = advice.handleVCIControllerExceptions(ex, request);
+
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals("invalid_request", response.getBody().getError());
+        Assert.assertEquals("Malformed JSON syntax error", response.getBody().getError_description());
+    }
+
+    @Test
+    public void testHandleVCIControllerExceptions_JsonMappingException() {
+        JsonMappingException cause = JsonMappingException.from(
+                (com.fasterxml.jackson.core.JsonParser) null, "msg"
+        );
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("msg", cause, null);
+
+        ResponseEntity<VCError> response = advice.handleVCIControllerExceptions(ex, request);
+
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals("invalid_request", response.getBody().getError());
+        Assert.assertEquals("Invalid request structure", response.getBody().getError_description());
+    }
+
+    @Test
+    public void testHandleVCIControllerExceptions_GenericReadableException() {
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("msg", (Throwable) null, null);
+
+        ResponseEntity<VCError> response = advice.handleVCIControllerExceptions(ex, request);
+
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals("invalid_request", response.getBody().getError());
+        Assert.assertEquals("Invalid JSON request body", response.getBody().getError_description());
+    }
+}

--- a/certify-service/src/test/java/io/mosip/certify/advice/ExceptionHandlerAdviceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/advice/ExceptionHandlerAdviceTest.java
@@ -20,7 +20,7 @@ public class ExceptionHandlerAdviceTest {
     private final HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
 
     @Test
-    public void testHandleVCIControllerExceptions_UnrecognizedPropertyException() {
+    public void should_returnInvalidRequest_when_unrecognizedPropertyIsProvided() {
         JsonParser parser = Mockito.mock(JsonParser.class);
         Mockito.when(parser.getCurrentLocation()).thenReturn(com.fasterxml.jackson.core.JsonLocation.NA);
         UnrecognizedPropertyException cause = UnrecognizedPropertyException.from(
@@ -36,7 +36,7 @@ public class ExceptionHandlerAdviceTest {
     }
 
     @Test
-    public void testHandleVCIControllerExceptions_InvalidFormatException() {
+    public void should_returnInvalidRequest_when_fieldFormatIsInvalid() {
         InvalidFormatException cause = InvalidFormatException.from(
                 null, "msg", "value", String.class
         );
@@ -50,7 +50,7 @@ public class ExceptionHandlerAdviceTest {
     }
 
     @Test
-    public void testHandleVCIControllerExceptions_JsonParseException() {
+    public void should_returnInvalidRequest_when_jsonSyntaxIsMalformed() {
         JsonParseException cause = new JsonParseException(null, "msg");
         HttpMessageNotReadableException ex = new HttpMessageNotReadableException("msg", cause, null);
 
@@ -62,7 +62,7 @@ public class ExceptionHandlerAdviceTest {
     }
 
     @Test
-    public void testHandleVCIControllerExceptions_JsonMappingException() {
+    public void should_returnInvalidRequest_when_requestStructureIsInvalid() {
         JsonMappingException cause = JsonMappingException.from(
                 (JsonParser) null, "msg"
         );
@@ -76,7 +76,7 @@ public class ExceptionHandlerAdviceTest {
     }
 
     @Test
-    public void testHandleVCIControllerExceptions_GenericReadableException() {
+    public void should_returnInvalidRequest_when_requestBodyIsUnreadable() {
         HttpMessageNotReadableException ex = new HttpMessageNotReadableException("msg", (Throwable) null, null);
 
         ResponseEntity<VCError> response = advice.handleVCIControllerExceptions(ex, request);

--- a/certify-service/src/test/java/io/mosip/certify/advice/ExceptionHandlerAdviceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/advice/ExceptionHandlerAdviceTest.java
@@ -1,6 +1,7 @@
 package io.mosip.certify.advice;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
@@ -20,7 +21,7 @@ public class ExceptionHandlerAdviceTest {
 
     @Test
     public void testHandleVCIControllerExceptions_UnrecognizedPropertyException() {
-        com.fasterxml.jackson.core.JsonParser parser = Mockito.mock(com.fasterxml.jackson.core.JsonParser.class);
+        JsonParser parser = Mockito.mock(JsonParser.class);
         Mockito.when(parser.getCurrentLocation()).thenReturn(com.fasterxml.jackson.core.JsonLocation.NA);
         UnrecognizedPropertyException cause = UnrecognizedPropertyException.from(
                 parser, Object.class, "unrecognized_field", null
@@ -63,7 +64,7 @@ public class ExceptionHandlerAdviceTest {
     @Test
     public void testHandleVCIControllerExceptions_JsonMappingException() {
         JsonMappingException cause = JsonMappingException.from(
-                (com.fasterxml.jackson.core.JsonParser) null, "msg"
+                (JsonParser) null, "msg"
         );
         HttpMessageNotReadableException ex = new HttpMessageNotReadableException("msg", cause, null);
 

--- a/certify-service/src/test/java/io/mosip/certify/advice/ExceptionHandlerAdviceTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/advice/ExceptionHandlerAdviceTest.java
@@ -46,7 +46,7 @@ public class ExceptionHandlerAdviceTest {
 
         Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         Assert.assertEquals("invalid_request", response.getBody().getError());
-        Assert.assertEquals("Invalid field format in request", response.getBody().getError_description());
+        Assert.assertEquals("Invalid format for field 'unknown' in request", response.getBody().getError_description());
     }
 
     @Test
@@ -72,7 +72,7 @@ public class ExceptionHandlerAdviceTest {
 
         Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         Assert.assertEquals("invalid_request", response.getBody().getError());
-        Assert.assertEquals("Invalid request structure", response.getBody().getError_description());
+        Assert.assertEquals("Invalid request structure for field 'unknown'", response.getBody().getError_description());
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
@@ -132,7 +132,7 @@ public class VCIssuanceControllerTest {
     }
 
     @Test
-    public void getVerifiableCredential_withMalformedJson_thenFail() throws Exception {
+    public void should_returnInvalidRequest_when_credentialRequestJsonIsMalformed() throws Exception {
         mockMvc.perform(post("/issuance/credential")
                         .content("{invalid-json}")
                         .contentType(MediaType.APPLICATION_JSON))

--- a/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/controller/VCIssuanceControllerTest.java
@@ -130,4 +130,14 @@ public class VCIssuanceControllerTest {
                 .andExpect(jsonPath("$.error").value(exception.getErrorCode()))
                 .andExpect(jsonPath("$.error_description").value(exception.getMessage()));
     }
+
+    @Test
+    public void getVerifiableCredential_withMalformedJson_thenFail() throws Exception {
+        mockMvc.perform(post("/issuance/credential")
+                        .content("{invalid-json}")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("invalid_request"))
+                .andExpect(jsonPath("$.error_description").value("Malformed JSON syntax error"));
+    }
 }


### PR DESCRIPTION
# Description  - Fix for #878 

This PR resolves an issue where malformed requests (for example, requests containing invalid properties such as `c_nonce` in the request body) sent to the VCI issuance endpoint resulted in a generic `unknown_error` with an HTTP `500 Internal Server Error` status.

With this change, JSON parsing and deserialization errors are properly intercepted, parsed, and translated into OpenID4VCI specification-compliant error responses, returned with an HTTP `400 Bad Request` status.

---

# Changes

## Global Exception Handling (`ExceptionHandlerAdvice.java`)

### VCI Controller Exception Handling

- Added direct interception of `HttpMessageNotReadableException` for the `/issuance/*` endpoints (`handleVCIControllerExceptions`).
- Extracted specific nested Jackson exceptions to provide more meaningful error responses:
  - `UnrecognizedPropertyException`
    - Returns details on unrecognized fields.
    
  - `InvalidFormatException`
    - Returns: Invalid field format in request
    
  - `JsonMappingException`
    - Returns: Invalid request structure
      
- Returns a structured VCI error response using `invalid_request` instead of the generic `unknown_error`.

---
When an invalid field ```c_nonce```
## Before Change (Actual)

```json
{
    "error": "unknown_error",
    "error_description": "JSON parse error: Unrecognized field \"c_nonce\" (class io.mosip.certify.core.dto.CredentialRequest), not marked as ignorable"
}
```

## After Change (Expected / Current Response)

```json
{
    "error": "invalid_request",
    "error_description": "Unrecognized field 'c_nonce' in request"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or unreadable request data, including invalid JSON.
  * Added clearer error messages for unrecognized fields, invalid formats, malformed syntax, and invalid request structures.
  * Such requests now consistently return a `400 Bad Request` response with an OAuth-style `invalid_request` error, helping clients identify and correct invalid credential issuance requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->