### PR TITLE
feat(metadata): return integer COSE algorithms for mso_mdoc format in… (954)

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialConfigurationSupportedDTO.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/dto/CredentialConfigurationSupportedDTO.java
@@ -27,7 +27,7 @@ public class CredentialConfigurationSupportedDTO {
     private List<String> cryptographicSuitesSupported;
 
     @JsonProperty("credential_signing_alg_values_supported")
-    private List<String> credentialSigningAlgValuesSupported;
+    private List<Object> credentialSigningAlgValuesSupported;
 
     @JsonProperty("proof_types_supported")
     private Map<String, Object> proofTypesSupported;

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -304,14 +304,21 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
 
         credentialConfigList.forEach(credentialConfig -> {
             CredentialConfigurationSupportedDTO dto = mapToSupportedDTO(credentialConfig);
+            List<String> algs;
             if (credentialConfig.getSignatureCryptoSuite() != null) {
-                dto.setCredentialSigningAlgValuesSupported(
-                        credentialSigningAlgValuesSupportedMap.get(credentialConfig.getSignatureCryptoSuite())
-                );
+                algs = credentialSigningAlgValuesSupportedMap.get(credentialConfig.getSignatureCryptoSuite());
             } else {
-                dto.setCredentialSigningAlgValuesSupported(
-                        Collections.singletonList(credentialConfig.getSignatureAlgo())
-                );
+                algs = Collections.singletonList(credentialConfig.getSignatureAlgo());
+            }
+
+            if (VCFormats.MSO_MDOC.equals(credentialConfig.getCredentialFormat()) && algs != null) {
+                List<Object> coseAlgs = new ArrayList<>();
+                for (String alg : algs) {
+                    coseAlgs.add(getCoseAlgorithm(alg));
+                }
+                dto.setCredentialSigningAlgValuesSupported(coseAlgs);
+            } else {
+                dto.setCredentialSigningAlgValuesSupported(algs != null ? new ArrayList<>(algs) : null);
             }
             credentialConfigurationSupportedMap.put(credentialConfig.getCredentialConfigKeyId(), dto);
         });
@@ -319,6 +326,17 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
         credentialIssuerMetadata.setCredentialConfigurationSupportedDTO(credentialConfigurationSupportedMap);
         populateCommonMetadataFields(credentialIssuerMetadata);
         return credentialIssuerMetadata;
+    }
+
+    public Object getCoseAlgorithm(String signAlgorithm) {
+        if (signAlgorithm == null) return null;
+        return switch (signAlgorithm) {
+            case "ES256" -> -7;
+            case "EdDSA" -> -8;
+            case "ES256K" -> -47;
+            case "RS256" -> -257;
+            default -> signAlgorithm;
+        };
     }
 
     private void populateCommonMetadataFields(CredentialIssuerMetadataDTO metadata) {

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -338,15 +338,15 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
     }
 
     public Integer getCoseAlgorithm(String signAlgorithm) {
-    if (signAlgorithm == null) {
-        throw new IllegalArgumentException("Missing COSE signing algorithm");
+        if (signAlgorithm == null) {
+            throw new IllegalArgumentException("Missing COSE signing algorithm");
+        }
+        Integer coseAlg = COSE_ALGORITHM_INTEGER_MAP.get(signAlgorithm);
+        if (coseAlg == null) {
+            throw new IllegalArgumentException("Unsupported COSE signing algorithm for mso_mdoc: " + signAlgorithm);
+        }
+        return coseAlg;
     }
-    Integer coseAlg = COSE_ALGORITHM_INTEGER_MAP.get(signAlgorithm);
-    if (coseAlg == null) {
-        throw new IllegalArgumentException("Unsupported COSE signing algorithm for mso_mdoc: " + signAlgorithm);
-    }
-    return coseAlg;
-}
 
 
     private void populateCommonMetadataFields(CredentialIssuerMetadataDTO metadata) {

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -28,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import java.util.*;
 import java.util.stream.Collectors;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.authlete.cose.constants.COSEAlgorithms;
 
 @Slf4j
 @Component
@@ -78,6 +80,13 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
 
 
     private static final String CREDENTIAL_CONFIG_CACHE_NAME = "credentialConfig";
+
+    private static final Map<String, Integer> COSE_ALGORITHM_INTEGER_MAP = Map.of(
+        JWSAlgorithm.ES256.getName(), COSEAlgorithms.ES256,
+        JWSAlgorithm.EdDSA.getName(), COSEAlgorithms.EdDSA,                
+        JWSAlgorithm.ES256K.getName(), COSEAlgorithms.ES256K,
+        JWSAlgorithm.RS256.getName(), COSEAlgorithms.RS256         
+    );
 
     @Override
     public CredentialConfigResponse addCredentialConfiguration(CredentialConfigurationDTO credentialConfigurationDTO) {
@@ -329,17 +338,16 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
     }
 
     public Integer getCoseAlgorithm(String signAlgorithm) {
-        if (signAlgorithm == null) {
-            throw new IllegalArgumentException("Missing COSE signing algorithm");
-        }
-        return switch (signAlgorithm) {
-            case "ES256" -> -7;
-            case "EdDSA" -> -8;
-            case "ES256K" -> -47;
-            case "RS256" -> -257;
-            default -> throw new IllegalArgumentException("Unsupported COSE signing algorithm for mso_mdoc: " + signAlgorithm);
-        };
+    if (signAlgorithm == null) {
+        throw new IllegalArgumentException("Missing COSE signing algorithm");
     }
+    Integer coseAlg = COSE_ALGORITHM_INTEGER_MAP.get(signAlgorithm);
+    if (coseAlg == null) {
+        throw new IllegalArgumentException("Unsupported COSE signing algorithm for mso_mdoc: " + signAlgorithm);
+    }
+    return coseAlg;
+}
+
 
     private void populateCommonMetadataFields(CredentialIssuerMetadataDTO metadata) {
         metadata.setCredentialIssuer(credentialIssuer);

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -328,14 +328,16 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
         return credentialIssuerMetadata;
     }
 
-    public Object getCoseAlgorithm(String signAlgorithm) {
-        if (signAlgorithm == null) return null;
+    public Integer getCoseAlgorithm(String signAlgorithm) {
+        if (signAlgorithm == null) {
+            throw new IllegalArgumentException("Missing COSE signing algorithm");
+        }
         return switch (signAlgorithm) {
             case "ES256" -> -7;
             case "EdDSA" -> -8;
             case "ES256K" -> -47;
             case "RS256" -> -257;
-            default -> signAlgorithm;
+            default -> throw new IllegalArgumentException("Unsupported COSE signing algorithm for mso_mdoc: " + signAlgorithm);
         };
     }
 

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
@@ -104,6 +104,7 @@ public class CredentialConfigurationSupportedServiceImplTest {
         Map<String, List<String>> credentialSigningMap = new LinkedHashMap<>();
         credentialSigningMap.put("Ed25519Signature2020", List.of("EdDSA"));
         credentialSigningMap.put("RsaSignature2018", List.of("RS256"));
+        credentialSigningMap.put("EcdsaSecp256r1Signature2019", List.of("ES256"));
         ReflectionTestUtils.setField(credentialConfigurationService, "cryptographicBindingMethodsSupportedMap", new LinkedHashMap<>());
         ReflectionTestUtils.setField(credentialConfigurationService, "credentialSigningAlgValuesSupportedMap", credentialSigningMap);
         ReflectionTestUtils.setField(credentialConfigurationService, "proofTypesSupported", new LinkedHashMap<>());
@@ -368,7 +369,27 @@ public class CredentialConfigurationSupportedServiceImplTest {
     }
 
     @Test
-    public void fetchCredentialIssuerMetadata_MsoMdocFormat() {
+    public void should_returnIntegerCoseAlgorithms_when_credentialFormatIsMsoMdoc() {
+        CredentialConfig config = new CredentialConfig();
+        config.setConfigId(UUID.randomUUID().toString());
+        config.setCredentialConfigKeyId("mdoc-credential");
+        config.setStatus("active");
+        config.setCredentialFormat("mso_mdoc");
+        config.setDocType("org.iso.18013.5.1.mDL");
+        config.setSignatureCryptoSuite("EcdsaSecp256r1Signature2019");
+
+        when(credentialConfigRepository.findAll()).thenReturn(List.of(config));
+        CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
+        dto.setCredentialFormat("mso_mdoc");
+        dto.setDocType("org.iso.18013.5.1.mDL");
+        when(credentialConfigMapper.toDto(config)).thenReturn(dto);
+
+        CredentialIssuerMetadataDTO result = credentialConfigurationService.fetchCredentialIssuerMetadata();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.getCredentialConfigurationSupportedDTO().containsKey("mdoc-credential"));
+        CredentialConfigurationSupportedDTO supportedDTO = result.getCredentialConfigurationSupportedDTO().get("mdoc-credential");
+        Assert.assertEquals(List.of(-7), supportedDTO.getCredentialSigningAlgValuesSupported());
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
@@ -393,6 +393,25 @@ public class CredentialConfigurationSupportedServiceImplTest {
     }
 
     @Test
+    public void should_throwException_when_msoMdocAlgorithmIsUnsupported() {
+        CredentialConfig config = new CredentialConfig();
+        config.setConfigId(UUID.randomUUID().toString());
+        config.setCredentialConfigKeyId("mdoc-invalid-alg");
+        config.setStatus("active");
+        config.setCredentialFormat("mso_mdoc");
+        config.setDocType("org.iso.18013.5.1.mDL");
+        config.setSignatureAlgo("UNSUPPORTED_ALG");
+
+        when(credentialConfigRepository.findAll()).thenReturn(List.of(config));
+        CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
+        dto.setCredentialFormat("mso_mdoc");
+        dto.setDocType("org.iso.18013.5.1.mDL");
+        when(credentialConfigMapper.toDto(config)).thenReturn(dto);
+
+        assertThrows(IllegalArgumentException.class, () -> credentialConfigurationService.fetchCredentialIssuerMetadata());
+    }
+
+    @Test
     public void addNewCredentialConfig_MsoMdoc_Success(){
         CredentialConfig mdocConfig = new CredentialConfig();
         mdocConfig.setConfigId(UUID.randomUUID().toString());

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
@@ -400,7 +400,14 @@ public class CredentialConfigurationSupportedServiceImplTest {
         config.setStatus("active");
         config.setCredentialFormat("mso_mdoc");
         config.setDocType("org.iso.18013.5.1.mDL");
-        config.setSignatureAlgo("UNSUPPORTED_ALG");
+        config.setSignatureCryptoSuite("EcdsaSecp256r1Signature2019");
+
+        LinkedHashMap<String, List<String>> unsupportedAlgorithms = new LinkedHashMap<>();
+        unsupportedAlgorithms.put("EcdsaSecp256r1Signature2019", List.of("UNSUPPORTED_ALG"));
+        ReflectionTestUtils.setField(
+                credentialConfigurationService,
+                "credentialSigningAlgValuesSupportedMap",
+                unsupportedAlgorithms);
 
         when(credentialConfigRepository.findAll()).thenReturn(List.of(config));
         CredentialConfigurationDTO dto = new CredentialConfigurationDTO();


### PR DESCRIPTION
Fixes - #954 
## Summary
Updated the well-known issuer metadata endpoint (`GET /.well-known/openid-credential-issuer`) to output integer COSE algorithm values (e.g., `-7` for `ES256`) in `credential_signing_alg_values_supported` for `mso_mdoc` credentials per the OpenID4VCI 1.0 spec, while maintaining string algorithm names for `mso_mdoc`, `ldp_vc` and `dc+sd-jwt`.

## Key Changes
- Updated `CredentialConfigurationSupportedDTO` to support serializing integer algorithm values.
- Mapped string algorithm names to COSE integer values (`ES256` → `-7`, `EdDSA` → `-8`, etc.) for `mso_mdoc` configurations in `CredentialConfigurationServiceImpl`.
- Added unit test coverage and verified endpoint response locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Credential issuer metadata now reports signing algorithms as COSE numeric identifiers for MSO mdoc credentials.
  * Added support for ES256, EdDSA, ES256K, and RS256 algorithm mappings.
  * Signing algorithms for other credential formats remain available in their existing string format.
  * Unsupported or missing mdoc signing algorithms are now rejected with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->