### PR TITLE
feat: add QrSettingsValidator to check for duplicate fields and valid… (679)

### DIFF
--- a/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
+++ b/certify-core/src/main/java/io/mosip/certify/core/constants/ErrorConstants.java
@@ -81,6 +81,8 @@ public class ErrorConstants {
     public static final String ERROR_SIGNING_QR_ENTRY = "error_signing_qr_entry";
     public static final String ERROR_SIGNING_QR_DATA = "error_signing_qr_data";
     public static final String QR_CBOR_ENCODING_ERROR = "qr_cbor_encoding_error";
+    public static final String QR_INVALID_FIELD_REFERENCE = "qr_invalid_field_reference";
+    public static final String DUPLICATE_FIELDS_IN_QR_SETTINGS = "duplicate_fields_in_qr_settings";
     public static final String INVALID_CREDENTIAL_CONFIGURATION_ID = "invalid_credential_configuration_id";
     public static final String MISSING_MANDATORY_CLAIM = "missing_mandatory_claim";
     public static final String CREDENTIAL_OFFER_NOT_FOUND = "credential_offer_not_found";

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialConfigurationServiceImpl.java
@@ -18,6 +18,7 @@ import io.mosip.certify.repository.CredentialConfigRepository;
 import io.mosip.certify.utils.CredentialConfigMapper;
 import io.mosip.certify.validators.credentialconfigvalidators.LdpVcCredentialConfigValidator;
 import io.mosip.certify.validators.credentialconfigvalidators.MsoMdocCredentialConfigValidator;
+import io.mosip.certify.validators.credentialconfigvalidators.QrSettingsValidator;
 import io.mosip.certify.validators.credentialconfigvalidators.SdJwtCredentialConfigValidator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -176,6 +177,7 @@ public class CredentialConfigurationServiceImpl implements CredentialConfigurati
             if (qrSignatureAlgo != null && !qrSignatureAlgo.isEmpty() && !keyAliasMapper.containsKey(qrSignatureAlgo)) {
                 throw new CertifyException(ErrorConstants.INVALID_QR_SIGNING_ALGORITHM, "The algorithm " + qrSignatureAlgo + " is not supported for QR signing. The supported values are: " + keyAliasMapper.keySet());
             }
+            QrSettingsValidator.validateQrSettings(qrSettings, vcTemplate);
         }
     }
 

--- a/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
@@ -45,7 +45,7 @@ public class QrSettingsValidator {
         try {
             byte[] decoded = Base64.getDecoder().decode(vcTemplate.trim());
             return new String(decoded, java.nio.charset.StandardCharsets.UTF_8);
-        } catch (Exception ignored) {
+        } catch (IllegalArgumentException ignored) {
             // If not base64 encoded or fails decoding, return raw vcTemplate
             return vcTemplate;
         }
@@ -89,8 +89,8 @@ public class QrSettingsValidator {
                     );
                 }
 
-                // 2. Check if field exists in templateVariables (if templateVariables is not empty)
-                if (templateVariables != null && !templateVariables.isEmpty()) {
+                // 2. Check if field exists in templateVariables (if templateVariables is provided)
+                if (templateVariables != null) {
                     if (!isFieldPresentInTemplate(varName, templateVariables)) {
                         throw new CertifyException(
                                 ErrorConstants.QR_INVALID_FIELD_REFERENCE,
@@ -108,8 +108,10 @@ public class QrSettingsValidator {
         }
         // Handle composite key like address#en.country -> check base field 'address' or 'country'
         if (varName.contains("#") || varName.contains(".")) {
-            String baseField = varName.split("[#.]")[0];
-            return templateVariables.contains(baseField);
+            String[] parts = varName.split("[#.]");
+            String rootField = parts[0];
+            String terminalField = parts[parts.length - 1];
+            return templateVariables.contains(rootField) || templateVariables.contains(terminalField);
         }
         return false;
     }

--- a/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class QrSettingsValidator {
 
-    private static final Pattern VELOCITY_VAR_PATTERN = Pattern.compile("\\$!?\\{?([a-zA-Z0-9_\\-#\\.]+)\\}?");
+    private static final Pattern VELOCITY_VAR_PATTERN = Pattern.compile("\\$!?\\{?([a-zA-Z_][a-zA-Z0-9_\\-#\\.]*)\\}?");
 
     /**
      * Validates qrSettings blocks for duplicate fields within a single block

--- a/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
@@ -38,6 +38,13 @@ public class QrSettingsValidator {
         }
     }
 
+    /**
+     * Decodes a Base64-encoded VC template string.
+     * If the template is already raw JSON or invalid Base64, returns the raw input.
+     *
+     * @param vcTemplate The input VC template string (Base64 or raw JSON)
+     * @return Decoded UTF-8 JSON string or raw input
+     */
     private static String decodeVcTemplate(String vcTemplate) {
         if (vcTemplate == null || vcTemplate.isEmpty()) {
             return vcTemplate;
@@ -51,6 +58,13 @@ public class QrSettingsValidator {
         }
     }
 
+    /**
+     * Extracts all Velocity variable names (e.g. ${fullName} -> "fullName")
+     * from a decoded VC template.
+     *
+     * @param decodedVcTemplate The decoded JSON template string
+     * @return Set of unique variable names found in the template
+     */
     private static Set<String> extractTemplateVariables(String decodedVcTemplate) {
         Set<String> variables = new HashSet<>();
         if (decodedVcTemplate == null || decodedVcTemplate.isEmpty()) {
@@ -63,6 +77,15 @@ public class QrSettingsValidator {
         return variables;
     }
 
+    /**
+     * Recursively traverses a QR settings block structure (maps, lists, strings),
+     * checking for duplicate field references within the block and verifying
+     * that referenced variables exist in the VC template.
+     *
+     * @param obj The element to traverse (Map, List, or String)
+     * @param seenInBlock Set tracking variable names already encountered in the current block
+     * @param templateVariables Set of valid variable names extracted from the VC template
+     */
     private static void extractAndValidateBlockVariables(Object obj, Set<String> seenInBlock, Set<String> templateVariables) {
         if (obj == null) {
             return;
@@ -102,6 +125,14 @@ public class QrSettingsValidator {
         }
     }
 
+    /**
+     * Checks if a variable name or its base/terminal field in composite notation
+     * exists within the set of valid template variables.
+     *
+     * @param varName The variable name referenced in QR settings
+     * @param templateVariables Set of valid template variable names
+     * @return true if the field or composite component exists in the template, false otherwise
+     */
     private static boolean isFieldPresentInTemplate(String varName, Set<String> templateVariables) {
         if (templateVariables.contains(varName)) {
             return true;

--- a/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
@@ -11,7 +11,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class QrSettingsValidator {
 
-    private static final Pattern VELOCITY_VAR_PATTERN = Pattern.compile("\\$!?\\{?([a-zA-Z_][a-zA-Z0-9_\\-#\\.]*)\\}?");
+    private static final Pattern VELOCITY_VAR_PATTERN = Pattern.compile("\\$!?\\{?([a-zA-Z][a-zA-Z0-9_\\-#\\.]*)\\}?");
 
     /**
      * Validates qrSettings blocks for duplicate fields within a single block

--- a/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
+++ b/certify-service/src/main/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidator.java
@@ -1,0 +1,116 @@
+package io.mosip.certify.validators.credentialconfigvalidators;
+
+import io.mosip.certify.core.constants.ErrorConstants;
+import io.mosip.certify.core.exception.CertifyException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Slf4j
+public class QrSettingsValidator {
+
+    private static final Pattern VELOCITY_VAR_PATTERN = Pattern.compile("\\$!?\\{?([a-zA-Z0-9_\\-#\\.]+)\\}?");
+
+    /**
+     * Validates qrSettings blocks for duplicate fields within a single block
+     * and ensures referenced fields exist in the vcTemplate.
+     *
+     * @param qrSettings List of QR code configuration blocks
+     * @param vcTemplate The VC Velocity template string
+     */
+    public static void validateQrSettings(List<Map<String, Object>> qrSettings, String vcTemplate) {
+        if (qrSettings == null || qrSettings.isEmpty()) {
+            return;
+        }
+
+        String decodedVcTemplate = decodeVcTemplate(vcTemplate);
+        Set<String> templateVariables = extractTemplateVariables(decodedVcTemplate);
+
+        for (Map<String, Object> blockMap : qrSettings) {
+            if (blockMap == null || blockMap.isEmpty()) {
+                continue;
+            }
+
+            Set<String> seenInBlock = new HashSet<>();
+            extractAndValidateBlockVariables(blockMap, seenInBlock, templateVariables);
+        }
+    }
+
+    private static String decodeVcTemplate(String vcTemplate) {
+        if (vcTemplate == null || vcTemplate.isEmpty()) {
+            return vcTemplate;
+        }
+        try {
+            byte[] decoded = Base64.getDecoder().decode(vcTemplate.trim());
+            return new String(decoded, java.nio.charset.StandardCharsets.UTF_8);
+        } catch (Exception ignored) {
+            // If not base64 encoded or fails decoding, return raw vcTemplate
+            return vcTemplate;
+        }
+    }
+
+    private static Set<String> extractTemplateVariables(String decodedVcTemplate) {
+        Set<String> variables = new HashSet<>();
+        if (decodedVcTemplate == null || decodedVcTemplate.isEmpty()) {
+            return variables;
+        }
+        Matcher matcher = VELOCITY_VAR_PATTERN.matcher(decodedVcTemplate);
+        while (matcher.find()) {
+            variables.add(matcher.group(1));
+        }
+        return variables;
+    }
+
+    private static void extractAndValidateBlockVariables(Object obj, Set<String> seenInBlock, Set<String> templateVariables) {
+        if (obj == null) {
+            return;
+        }
+
+        if (obj instanceof Map<?, ?> map) {
+            for (Object value : map.values()) {
+                extractAndValidateBlockVariables(value, seenInBlock, templateVariables);
+            }
+        } else if (obj instanceof List<?> list) {
+            for (Object item : list) {
+                extractAndValidateBlockVariables(item, seenInBlock, templateVariables);
+            }
+        } else if (obj instanceof String strVal) {
+            Matcher matcher = VELOCITY_VAR_PATTERN.matcher(strVal);
+            while (matcher.find()) {
+                String varName = matcher.group(1);
+
+                // 1. Check for duplicate field references within the single block
+                if (!seenInBlock.add(varName)) {
+                    throw new CertifyException(
+                            ErrorConstants.DUPLICATE_FIELDS_IN_QR_SETTINGS,
+                            "Duplicate field '" + varName + "' found in a single qrSettings block."
+                    );
+                }
+
+                // 2. Check if field exists in templateVariables (if templateVariables is not empty)
+                if (templateVariables != null && !templateVariables.isEmpty()) {
+                    if (!isFieldPresentInTemplate(varName, templateVariables)) {
+                        throw new CertifyException(
+                                ErrorConstants.QR_INVALID_FIELD_REFERENCE,
+                                "Field '" + varName + "' referenced in qrSettings is not present in VC template."
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean isFieldPresentInTemplate(String varName, Set<String> templateVariables) {
+        if (templateVariables.contains(varName)) {
+            return true;
+        }
+        // Handle composite key like address#en.country -> check base field 'address' or 'country'
+        if (varName.contains("#") || varName.contains(".")) {
+            String baseField = varName.split("[#.]")[0];
+            return templateVariables.contains(baseField);
+        }
+        return false;
+    }
+}

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialConfigurationSupportedServiceImplTest.java
@@ -1,6 +1,7 @@
 package io.mosip.certify.services;
 
 import io.mosip.certify.core.dto.*;
+import io.mosip.certify.core.constants.ErrorConstants;
 import io.mosip.certify.core.constants.VCFormats;
 import io.mosip.certify.core.exception.CertifyException;
 import io.mosip.certify.core.exception.CredentialConfigException;
@@ -699,7 +700,7 @@ public class CredentialConfigurationSupportedServiceImplTest {
     }
 
     @Test
-    public void validateCredentialConfiguration_QrSettingsNull_QrSignatureAlgoSet_ThrowsException() {
+    public void should_throwCertifyException_when_qrSettingsNullAndQrSignatureAlgoSet() {
         CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
         dto.setCredentialFormat("ldp_vc");
         dto.setVcTemplate("test_template");
@@ -713,7 +714,7 @@ public class CredentialConfigurationSupportedServiceImplTest {
     }
 
     @Test
-    public void validateCredentialConfiguration_QrSettingsEmpty_QrSignatureAlgoSet_ThrowsException() {
+    public void should_throwCertifyException_when_qrSettingsEmptyAndQrSignatureAlgoSet() {
         CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
         dto.setCredentialFormat("ldp_vc");
         dto.setVcTemplate("test_template");
@@ -727,7 +728,7 @@ public class CredentialConfigurationSupportedServiceImplTest {
     }
 
     @Test
-    public void validateCredentialConfiguration_QrSettingsPresent_UnsupportedQrSignatureAlgo_ThrowsException() {
+    public void should_throwCertifyException_when_qrSignatureAlgoUnsupported() {
         CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
         dto.setCredentialFormat("ldp_vc");
         dto.setVcTemplate("test_template");
@@ -742,7 +743,7 @@ public class CredentialConfigurationSupportedServiceImplTest {
     }
 
     @Test
-    public void validateCredentialConfiguration_QrSettingsPresent_SupportedQrSignatureAlgo_AllowsConfig() {
+    public void should_allowCredentialConfiguration_when_qrSignatureAlgoSupported() {
         CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
         dto.setCredentialFormat("ldp_vc");
         dto.setVcTemplate("test_template");
@@ -757,6 +758,40 @@ public class CredentialConfigurationSupportedServiceImplTest {
             mocked.when(() -> LdpVcCredentialConfigValidator.isValidCheck(dto)).thenReturn(true);
             ReflectionTestUtils.invokeMethod(credentialConfigurationService, "validateCredentialConfiguration", dto, true);
         }
+    }
+
+    @Test
+    public void should_allowCredentialConfiguration_when_qrSettingsValidInBase64VcTemplate() {
+        String template = "{\"credentialSubject\":{\"fullName\":\"${fullName}\"}}";
+        String base64Template = java.util.Base64.getEncoder().encodeToString(template.getBytes());
+        CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
+        dto.setCredentialFormat("ldp_vc");
+        dto.setVcTemplate(base64Template);
+        dto.setQrSettings(List.of(Map.of("Full Name", "${fullName}")));
+        dto.setSignatureAlgo("EdDSA");
+        dto.setKeyManagerAppId("TEST2019");
+        dto.setKeyManagerRefId("TEST2019-REF");
+        ReflectionTestUtils.setField(credentialConfigurationService, "pluginMode", "DataProvider");
+        ReflectionTestUtils.setField(credentialConfigurationService, "keyAliasMapper", Map.of("EdDSA", List.of(List.of("TEST2019", "TEST2019-REF"))));
+        try (var mocked = org.mockito.Mockito.mockStatic(LdpVcCredentialConfigValidator.class)) {
+            mocked.when(() -> LdpVcCredentialConfigValidator.isValidCheck(dto)).thenReturn(true);
+            ReflectionTestUtils.invokeMethod(credentialConfigurationService, "validateCredentialConfiguration", dto, true);
+        }
+    }
+
+    @Test
+    public void should_throwCertifyException_when_qrSettingsFieldMissingInBase64VcTemplate() {
+        String template = "{\"credentialSubject\":{\"fullName\":\"${fullName}\"}}";
+        String base64Template = java.util.Base64.getEncoder().encodeToString(template.getBytes());
+        CredentialConfigurationDTO dto = new CredentialConfigurationDTO();
+        dto.setCredentialFormat("ldp_vc");
+        dto.setVcTemplate(base64Template);
+        dto.setQrSettings(List.of(Map.of("Invalid Field", "${unknownField}")));
+        ReflectionTestUtils.setField(credentialConfigurationService, "pluginMode", "DataProvider");
+        CertifyException ex = assertThrows(CertifyException.class, () ->
+                ReflectionTestUtils.invokeMethod(credentialConfigurationService, "validateCredentialConfiguration", dto, true)
+        );
+        assertEquals(ErrorConstants.QR_INVALID_FIELD_REFERENCE, ex.getErrorCode());
     }
 
     @Test

--- a/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidatorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidatorTest.java
@@ -97,4 +97,27 @@ public class QrSettingsValidatorTest {
         assertEquals(ErrorConstants.QR_INVALID_FIELD_REFERENCE, ex.getErrorCode());
         assertTrue(ex.getMessage().contains("Field 'name'"));
     }
+
+    @Test
+    public void should_throwException_when_vcTemplateHasNoVariablesButQrSettingsHasField() {
+        String emptyVcTemplate = "{\"credentialSubject\": {}}";
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Field", "${unknownField}")
+        );
+
+        CertifyException ex = assertThrows(CertifyException.class,
+                () -> QrSettingsValidator.validateQrSettings(qrSettings, emptyVcTemplate));
+
+        assertEquals(ErrorConstants.QR_INVALID_FIELD_REFERENCE, ex.getErrorCode());
+    }
+
+    @Test
+    public void should_validateSuccessfully_when_compositeFieldMatchesTerminalFieldInTemplate() {
+        String templateWithTerminal = "{\"credentialSubject\": {\"country\": \"${country}\"}}";
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Country", "${address#en.country}")
+        );
+
+        assertDoesNotThrow(() -> QrSettingsValidator.validateQrSettings(qrSettings, templateWithTerminal));
+    }
 }

--- a/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidatorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidatorTest.java
@@ -1,0 +1,100 @@
+package io.mosip.certify.validators.credentialconfigvalidators;
+
+import io.mosip.certify.core.constants.ErrorConstants;
+import io.mosip.certify.core.exception.CertifyException;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class QrSettingsValidatorTest {
+
+    private final String sampleVcTemplate = """
+            {
+              "credentialSubject": {
+                "fullName": "${fullName}",
+                "mobileNumber": "${mobileNumber}",
+                "dateOfBirth": "${dateOfBirth}",
+                "face": "${face}"
+              }
+            }
+            """;
+
+    @Test
+    public void should_doNothing_when_qrSettingsNullOrEmpty() {
+        assertDoesNotThrow(() -> QrSettingsValidator.validateQrSettings(null, sampleVcTemplate));
+        assertDoesNotThrow(() -> QrSettingsValidator.validateQrSettings(Collections.emptyList(), sampleVcTemplate));
+    }
+
+    @Test
+    public void should_validateSuccessfully_when_qrSettingsValidAndFieldsExistInVcTemplate() {
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Full Name", "${fullName}", "Phone", "${mobileNumber}"),
+                Map.of("DOB", "${dateOfBirth}", "Photo", "${face}")
+        );
+
+        assertDoesNotThrow(() -> QrSettingsValidator.validateQrSettings(qrSettings, sampleVcTemplate));
+    }
+
+    @Test
+    public void should_throwException_when_duplicateFieldsInSingleQrBlock() {
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Full Name", "${fullName}", "Name Duplicate", "${fullName}")
+        );
+
+        CertifyException ex = assertThrows(CertifyException.class,
+                () -> QrSettingsValidator.validateQrSettings(qrSettings, sampleVcTemplate));
+
+        assertEquals(ErrorConstants.DUPLICATE_FIELDS_IN_QR_SETTINGS, ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("Duplicate field 'fullName'"));
+    }
+
+    @Test
+    public void should_throwException_when_fieldReferencedInQrSettingsMissingFromVcTemplate() {
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Full Name", "${fullName}", "Invalid Field", "${unsupportedField}")
+        );
+
+        CertifyException ex = assertThrows(CertifyException.class,
+                () -> QrSettingsValidator.validateQrSettings(qrSettings, sampleVcTemplate));
+
+        assertEquals(ErrorConstants.QR_INVALID_FIELD_REFERENCE, ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("Field 'unsupportedField'"));
+    }
+
+    @Test
+    public void should_allowSameFieldInDifferentBlocks_when_fieldsInSeparateBlocks() {
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Full Name Block 1", "${fullName}"),
+                Map.of("Full Name Block 2", "${fullName}")
+        );
+
+        assertDoesNotThrow(() -> QrSettingsValidator.validateQrSettings(qrSettings, sampleVcTemplate));
+    }
+
+    @Test
+    public void should_validateSuccessfully_when_vcTemplateIsBase64Encoded() {
+        String base64Template = java.util.Base64.getEncoder().encodeToString(sampleVcTemplate.getBytes());
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Full Name", "${fullName}", "Phone", "${mobileNumber}")
+        );
+
+        assertDoesNotThrow(() -> QrSettingsValidator.validateQrSettings(qrSettings, base64Template));
+    }
+
+    @Test
+    public void should_throwException_when_fieldIsSubstringOfTemplateVariable() {
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Short Name", "${name}")
+        );
+
+        CertifyException ex = assertThrows(CertifyException.class,
+                () -> QrSettingsValidator.validateQrSettings(qrSettings, sampleVcTemplate));
+
+        assertEquals(ErrorConstants.QR_INVALID_FIELD_REFERENCE, ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("Field 'name'"));
+    }
+}

--- a/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidatorTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/validators/credentialconfigvalidators/QrSettingsValidatorTest.java
@@ -120,4 +120,13 @@ public class QrSettingsValidatorTest {
 
         assertDoesNotThrow(() -> QrSettingsValidator.validateQrSettings(qrSettings, templateWithTerminal));
     }
+
+    @Test
+    public void should_ignoreCurrencyLiterals_when_qrSettingsContainsDollarAmount() {
+        List<Map<String, Object>> qrSettings = List.of(
+                Map.of("Full Name", "${fullName}", "Price", "Amount: $2.50")
+        );
+
+        assertDoesNotThrow(() -> QrSettingsValidator.validateQrSettings(qrSettings, sampleVcTemplate));
+    }
 }


### PR DESCRIPTION
Fixes - [#679](https://github.com/inji/inji-certify/issues/679)
### Improve Credential Configuration
- Catch duplicate field when qrSettings are being created or updated
- Catch invalid field if some filed(s) are not available in the VC template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added QR settings validation during credential configuration.
  * QR field references are checked against the VC template, including Base64-encoded templates and composite fields.
  * Duplicate field references within a QR block are rejected with clear error codes.
  * Added validation feedback for missing or invalid QR field references.

* **Tests**
  * Added coverage for valid, invalid, duplicate, missing, composite, and encoded-template QR configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->