### PR TITLE
update plugins pom to 1.0.0-beta.1-SNAPSHOT

### DIFF
--- a/certify-service-with-plugins/Dockerfile
+++ b/certify-service-with-plugins/Dockerfile
@@ -1,4 +1,4 @@
-FROM injistack/inji-certify:1.0.0-alpha.1
+FROM injistackdev/inji-certify:develop
 
 ARG SOURCE
 ARG COMMIT_HASH

--- a/certify-service-with-plugins/pom.xml
+++ b/certify-service-with-plugins/pom.xml
@@ -34,13 +34,13 @@
 
     <properties>
         <certify-plugins.location>target</certify-plugins.location>
-        <mock-certify-plugin.version>1.0.0-alpha.1</mock-certify-plugin.version>
+        <mock-certify-plugin.version>1.0.0-beta.1-SNAPSHOT</mock-certify-plugin.version>
         <mock-certify-plugin.fileName>mock-certify-plugin.jar</mock-certify-plugin.fileName>
-        <mosip-identity-certify-plugin.version>1.0.0-alpha.1</mosip-identity-certify-plugin.version>
+        <mosip-identity-certify-plugin.version>1.0.0-beta.1-SNAPSHOT</mosip-identity-certify-plugin.version>
         <mosip-identity-certify-plugin.fileName>mosip-identity-certify-plugin.jar</mosip-identity-certify-plugin.fileName>
-        <postgres-dataprovider-plugin.version>1.0.0-alpha.1</postgres-dataprovider-plugin.version>
+        <postgres-dataprovider-plugin.version>1.0.0-beta.1-SNAPSHOT</postgres-dataprovider-plugin.version>
         <postgres-dataprovider-plugin.fileName>postgres-dataprovider-plugin.jar</postgres-dataprovider-plugin.fileName>
-        <sunbird-rc-certify-integration-plugin.version>1.0.0-alpha.1</sunbird-rc-certify-integration-plugin.version>
+        <sunbird-rc-certify-integration-plugin.version>1.0.0-beta.1-SNAPSHOT</sunbird-rc-certify-integration-plugin.version>
         <sunbird-rc-certify-integration-plugin.fileName>sunbird-rc-certify-integration-impl.jar</sunbird-rc-certify-integration-plugin.fileName>
     </properties>
     <build>

--- a/docker-compose/docker-compose-injistack/docker-compose.yaml
+++ b/docker-compose/docker-compose-injistack/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
       - "5433:5432"
 
   certify:
-    image: injistack/inji-certify-with-plugins:1.0.0-alpha.1
+    image: injistackdev/inji-certify-with-plugins:develop
     user: root
     ports:
       - 8090:8090
@@ -64,7 +64,7 @@ services:
 
   mimoto-service:
     container_name: 'mimoto-service'
-    image: injistackint/mimoto:1.0.x
+    image: injistack/mimoto:1.0.0-alpha.1
     user: root
     ports:
       - '8099:8099'
@@ -95,7 +95,7 @@ services:
 
   inji-web:
     container_name: 'inji-web'
-    image: injistackint/inji-web:1.0.x
+    image: injistack/inji-web:1.0.0-alpha.1
     ports:
       - '3004:3004'
     environment:


### PR DESCRIPTION
#1017 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bundled plugin components to the `1.0.0-beta.1-SNAPSHOT` release versions.
  * Updated the Certify service container to use the development image.
  * Updated the Docker Compose service images for Certify, Mimoto, and Inji Web to their latest configured image versions, improving alignment across the local deployment stack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->