### PR TITLE
update helm chart to 1.0.0-beta.1-develop

### DIFF
--- a/deploy/inji-certify/install.sh
+++ b/deploy/inji-certify/install.sh
@@ -13,7 +13,7 @@ echo "Create $SOFTHSM_NS namespace"
 kubectl create ns $SOFTHSM_NS
 
 NS=inji-certify
-CHART_VERSION=1.0.0-alpha.1-develop
+CHART_VERSION=1.0.0-beta.1-develop
 
 echo "Create $NS namespace"
 kubectl create ns $NS

--- a/helm/inji-certify/Chart.yaml
+++ b/helm/inji-certify/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: inji-certify
 description: A Helm chart for inji certify service
 type: application
-version: 1.0.0-alpha.1-develop
+version: 1.0.0-beta.1-develop
 appVersion: ""
 dependencies:
   - name: common

--- a/helm/inji-certify/values.yaml
+++ b/helm/inji-certify/values.yaml
@@ -52,8 +52,8 @@ service:
 
 image:
   registry: docker.io
-  repository: injistack/inji-certify-with-plugins
-  tag: 1.0.0-alpha.1
+  repository: injistackqa/inji-certify-with-plugins
+  tag: develop
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Inji Certify Helm chart to version `1.0.0-beta.1-develop`.
  * Updated the default container image configuration to use the QA image repository and the `develop` image tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->