### PR TITLE
INJICERT #1015 - Update Certify Endpoints with CSRF Token

### DIFF
--- a/api-test/src/main/java/io/inji/testrig/apirig/injicertify/testrunner/InjiTestRunner.java
+++ b/api-test/src/main/java/io/inji/testrig/apirig/injicertify/testrunner/InjiTestRunner.java
@@ -118,6 +118,9 @@ public class InjiTestRunner {
 				}
 			}
 
+			// Needed for every use case, not just mosipid, else eSignet returns 403 Forbidden
+			AdminTestUtil.fetchAndStoreCsrfToken();
+			
 			if (useCaseToExecute.equalsIgnoreCase("mosipid")) {
 
 				InjiCertifyUtil.dBCleanup();

--- a/api-test/src/main/java/io/inji/testrig/apirig/injicertify/testrunner/InjiTestRunner.java
+++ b/api-test/src/main/java/io/inji/testrig/apirig/injicertify/testrunner/InjiTestRunner.java
@@ -140,7 +140,9 @@ public class InjiTestRunner {
 
 			}
 		} catch (Exception e) {
-			LOGGER.error("Exception " + e.getMessage());
+			LOGGER.error("Exception " + e.getMessage(), e);
+			// Fatal init/run failure: exit non-zero instead of falling through to the success path
+			System.exit(1);
 		}
 
 		if (useCaseToExecute.equalsIgnoreCase("landregistry")) {

--- a/api-test/src/main/resources/config/injiCertify.properties
+++ b/api-test/src/main/resources/config/injiCertify.properties
@@ -5,6 +5,7 @@ actuatorMasterDataEndpoint=/v1/masterdata/actuator/env
 actuatorIDAEndpoint=/idauthentication/v1/actuator/env
 actuatorEsignetEndpoint=/v1/esignet/actuator/env
 actuatorCertifyEndpoint=/v1/certify/actuator/env
+csrfTokenEndpoint=/v1/esignet/csrf/token
 certifyActuatorPropertySection=
 tokenEndpoint=/v1/esignet/oauth/token
 esignetWellKnownEndPoint=/v1/esignet/oidc/.well-known/openid-configuration


### PR DESCRIPTION
Fetch the CSRF token from the eSignet `/v1/esignet/csrf/token` endpoint at test-run startup and store it via `AdminTestUtil.fetchAndStoreCsrfToken()`, so it's automatically attached as the `X-XSRF-TOKEN` header/cookie on subsequent requests instead of relying on a static, stale value. Added `csrfTokenEndpoint` in `injiCertify.properties` pointing to the correct eSignet path, resolving requests that previously sent a null/invalid CSRF token and got rejected with `403 Forbidden`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSRF tokens are now fetched consistently across all test execution paths.
  * Added configuration for the CSRF token endpoint.
  * Test execution now reports initialization or runtime failures with detailed error information and exits with a failure status instead of indicating success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->