### PR TITLE
INJICERT #1017 update the docker-compose, local-development readme files

### DIFF
--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -402,5 +402,5 @@ docker-compose down -v
 
 ### Presentation During Issuance (PDI)
 
-Certify supports the **Presentation During Issuance** flow using the embedded **verify-core** library (bundled in-process within the `inji-certify-with-plugins` image) — there is no separate `verify-service` container to run.
+Certify supports the **Presentation During Issuance** flow using the embedded **verify-core** library, which is a dependency of the Certify service and runs in-process — there is no separate `verify-service` container to run.
 

--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -191,7 +191,6 @@ The following services will be available:
 - Certify Nginx: `localhost:8091`
 - Mimoto Service: `localhost:8099`
 - Inji Web: `localhost:3004`
-- Inji Verify: `localhost:8095`
 
 ## Using the Application
 
@@ -401,7 +400,7 @@ docker-compose down -v
 - [Inji Documentation](https://docs.inji.io/)
 
 
-### Verify Service
+### Presentation During Issuance (PDI)
 
-The verify-service is commented out by default in the `docker-compose.yml`.  
-If you want to explore the Presentation During Issuance feature and test the end-to-end issuance + verification flow**, uncomment the `verify-service` and restart the stack.
+Certify supports the **Presentation During Issuance** flow using the embedded **verify-core** library (bundled in-process within the `inji-certify-with-plugins` image) — there is no separate `verify-service` container to run.
+

--- a/docker-compose/docker-compose-injistack/README.md
+++ b/docker-compose/docker-compose-injistack/README.md
@@ -48,13 +48,24 @@ docker-compose-injistack/
 │   ├── certify-default.properties
 │   ├── certify-csvdp-farmer.properties
 │   ├── certify-mock-mdl.properties
+│   ├── certify-mdl-pdi.properties
+│   ├── farmer_identity_data.csv
+│   ├── driving_license_mosipid.csv
+│   ├── vp_request_config.json
+│   ├── mimoto-bootstrap.properties
 │   ├── mimoto-default.properties
 │   ├── mimoto-issuers-config.json
 │   ├── mimoto-trusted-verifiers.json
+│   ├── mosip-cbeff.xsd
 │   └── credential-template.html
+├── context/
+│   ├── farmer-context.json
+│   └── mdl-pdi-context.json
 ├── nginx.conf
+├── certify-nginx.conf
 ├── certify_init.sql
-└── docker-compose.yml
+├── mimoto_init.sql
+└── docker-compose.yaml
 ```
 
 
@@ -154,6 +165,10 @@ Ensure all configuration files are properly updated in the config directory if y
 
 - certify-default.properties
 - certify-csvdp-farmer.properties
+- certify-mock-mdl.properties
+- certify-mdl-pdi.properties
+- vp_request_config.json (drives the Presentation During Issuance flow)
+- context/farmer-context.json, context/mdl-pdi-context.json (JSON-LD @context files)
 
 Following files are optional and can be used to configure the Inji Web application for your usecase, if you are not using web application, you can skip these files:
 
@@ -241,7 +256,7 @@ The digest multibase can be hardcoded or if the template has been stored with Ce
 - Second is `Sign in with Google` which requires Google OAuth credentials to be setup.
 ## To configure your own Google Auth Credentials:
 - Refer to the steps documented in the `mimoto` for the same. [GOOGLE_AUTH_SETUP](https://github.com/inji/mimoto/blob/master/docker-compose/README.md#how-to-create-google-client-credentials)
-- Replace the placeholders under the `mimoto-service` in the `docker-compose.yml` file with the generated credentials:
+- Replace the placeholders under the `mimoto-service` in the `docker-compose.yaml` file with the generated credentials:
 
    ```yaml
        environment:
@@ -332,7 +347,7 @@ The digest multibase can be hardcoded or if the template has been stored with Ce
     - Replace certify:8090 with your actual backend service name and port.
     - If you're using Docker, ensure the backend and NGINX are on the same network.
     - For HTTPS, add SSL configuration (`listen 443 ssl;`, `ssl_certificate`, etc.).
-3. **Integrate with Docker Compose**: Update your docker-compose.yml:
+3. **Integrate with Docker Compose**: Update your docker-compose.yaml:
 ```yaml
     services:
         nginx:

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -8,7 +8,7 @@
 1. Clone the repo, usually the active development happens on the `develop` branch but one can check out a tagged version as well.
 2. Run the DB init scripts present in `db_scripts/inji_certify` , running `./deploy.sh deploy.properties` is a good way to init the DB.
 3. Decide on the issuance mode of Certify. Some plugins enable Certify to operate as a Proxy and others enable it to work as an Issuer, configure `mosip.certify.plugin-mode` appropriately as `DataProvider` or `VCIssuance`.
-    * [Recommended] Set it to `DataProvider` if you want a quickest possible working setup, and configure `mosip.certify.data-provider-plugin.issuer-public-key-uri` appropriately.
+    * [Recommended] Set it to `DataProvider` if you want a quickest possible working setup, and configure `mosip.certify.data-provider-plugin.did-url` appropriately.
     * If you have another Issuance module such as Sunbird, MOSIP Stack, you may want to set it up in `VCIssuance` mode.
 4. Decide on the VCI plugin for use locally and configure it, while running locally from an IDE such as Eclipse or IntelliJ one needs to add configuration to the `application-local.properties` and add the VCI plugin dependency JAR to the certify-service project which implements one of `DataProviderPlugin` or `VCIssuancePlugin` interfaces.
 5. Get a compatible eSignet setup running configured with the appropriate Authenticator plugin implementation matching the VCI plugin.

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -14,8 +14,7 @@
 5. Get a compatible eSignet setup running configured with the appropriate Authenticator plugin implementation matching the VCI plugin.
     * Configure `mosip.certify.authorization.url` to point to your Authorization service hostname, this could be a working eSignet instance or another AuthZ provider configured with an [Authenticator plugin implementation](https://docs.esignet.io/integration/authenticator), essentially enabling the VC Issuing plugin to do the work.
     * Configure `mosip.certify.domain.url`, `mosip.certify.identifier`, `mosip.certify.authn.issuer-uri`, `mosip.certify.authn.jwk-set-uri`, `mosip.certify.authn.allowed-audiences` appropriately as per the Authorization service and Certify URI.
-    * Update the `mosip.certify.key-values` with the well known appropriately, with the correct credential-type, scope and other relevant attributes.
-    * Update the well known configuration in `mosip.certify.key-values` to match the Credential type, scope and other fields to match your VerifiableCredential.
+    * Configure your Verifiable Credential types, scopes and other well-known attributes via the `/credential-configurations` API (stored in the `credential_config` table). Refer to [Credential-Issuer-Configuration.md](./Credential-Issuer-Configuration.md) for details.
     * Appropriately configure the `mosip.certify.authn.allowed-audiences` to allowed audiences such that it matches with the AuthZ token when the Credential issue request is made to Certify.
 6. (required if Mobile driving license configured) Onboard issuer key and certificate data into property `mosip.certify.mock.mdoc.issuer-key-cert` using the creation script.
 7. Perform Authentication & VC Issuance to see if the Certify & AuthZ stack is working apprpriately. Look out for the Postman collections referred to in the main README.md of this project.
@@ -154,23 +153,23 @@ mvn clean install -Dgpg.skip=true
 ## Setting up Presentation During Issuance
 To setup presentation requirement during issuance, follow the steps below:
 1. **Configuration:** Use the following properties in `application-local.properties` to setup presentation requirement during issuance.
-```properties
-## Use certify as Auth Server
-# Use below properties to use certify as authorization server
-#mosip.certify.authorization.url=http://localhost:8090
-#mosip.certify.authn.issuer-uri=${mosip.certify.authorization.url}
-#mosip.certify.authn.jwk-set-uri=${mosip.certify.authorization.url}${server.servlet.path}/.well-known/jwks.json
-#mosip.certify.authn.allowed-audiences={ '${mosip.certify.authorization.url}${server.servlet.path}/issuance/credential' }
+   ```properties
+   ## Use certify as Auth Server
+   # Use below properties to use certify as authorization server
+   #mosip.certify.authorization.url=http://localhost:8090
+   #mosip.certify.authn.issuer-uri=${mosip.certify.authorization.url}
+   #mosip.certify.authn.jwk-set-uri=${mosip.certify.authorization.url}${server.servlet.path}/.well-known/jwks.json
+   #mosip.certify.authn.allowed-audiences={ '${mosip.certify.authorization.url}${server.servlet.path}/issuance/credential' }
 
-## Auth Server Configurations
-mosip.certify.oauth.issuer=${mosip.certify.authorization.url}
-mosip.certify.oauth.token-endpoint=${mosip.certify.authorization.url}${server.servlet.path}/oauth/token
-mosip.certify.oauth.jwks-uri=${mosip.certify.authorization.url}${server.servlet.path}/.well-known/jwks.json
-mosip.certify.oauth.grant-types-supported=authorization_code,urn:ietf:params:oauth:grant-type:pre-authorized_code
-mosip.certify.oauth.response-types-supported=code
-mosip.certify.oauth.code-challenge-methods-supported=S256
-mosip.certify.oauth.interactive-authorization-endpoint=${mosip.certify.authorization.url}${server.servlet.path}/oauth/iae
-```
+   ## Auth Server Configurations
+   mosip.certify.oauth.issuer=${mosip.certify.authorization.url}
+   mosip.certify.oauth.token-endpoint=${mosip.certify.authorization.url}${server.servlet.path}/oauth/token
+   mosip.certify.oauth.jwks-uri=${mosip.certify.authorization.url}${server.servlet.path}/.well-known/jwks.json
+   mosip.certify.oauth.grant-types-supported=authorization_code,urn:ietf:params:oauth:grant-type:pre-authorized_code
+   mosip.certify.oauth.response-types-supported=code
+   mosip.certify.oauth.code-challenge-methods-supported=S256
+   mosip.certify.oauth.interactive-authorization-endpoint=${mosip.certify.authorization.url}${server.servlet.path}/oauth/iae
+   ```
 2. **Local VP Request Configuration:** `application-local.properties` points `mosip.certify.vp-request.config-file-url` to `vp_request_config-local.json`. This file contains hardcoded `clientId` and `nonce` values that match the sample DCQL VP token used by the Postman collection, so the embedded Inji Verify library's signature / domain / challenge checks pass without regenerating a VP for every run. Deployment configurations should continue to use `vp_request_config.json` (no hardcoded `clientId` / `nonce`).
 3. Import the **Inji Certify - Presentation During Issuance VCI** collection and the [presentation-during-issuance environment](./postman-collections/Inji-certify-presentation-during-issuance.postman_environment.json) from [docs/postman-collections](./postman-collections/) to test the flow, running the requests in order:
 4. Use the `1. Discovery Endpoints Copy` folder to fetch the issuer and OAuth authorization-server metadata endpoints.

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -8,7 +8,7 @@
 1. Clone the repo, usually the active development happens on the `develop` branch but one can check out a tagged version as well.
 2. Run the DB init scripts present in `db_scripts/inji_certify` , running `./deploy.sh deploy.properties` is a good way to init the DB.
 3. Decide on the issuance mode of Certify. Some plugins enable Certify to operate as a Proxy and others enable it to work as an Issuer, configure `mosip.certify.plugin-mode` appropriately as `DataProvider` or `VCIssuance`.
-    * [Recommended] Set it to `DataProvider` if you want a quickest possible working setup, and configure `mosip.certify.data-provider-plugin.issuer-uri` and `mosip.certify.data-provider-plugin.issuer-public-key-uri` appropriately.
+    * [Recommended] Set it to `DataProvider` if you want a quickest possible working setup, and configure `mosip.certify.data-provider-plugin.issuer-public-key-uri` appropriately.
     * If you have another Issuance module such as Sunbird, MOSIP Stack, you may want to set it up in `VCIssuance` mode.
 4. Decide on the VCI plugin for use locally and configure it, while running locally from an IDE such as Eclipse or IntelliJ one needs to add configuration to the `application-local.properties` and add the VCI plugin dependency JAR to the certify-service project which implements one of `DataProviderPlugin` or `VCIssuancePlugin` interfaces.
 5. Get a compatible eSignet setup running configured with the appropriate Authenticator plugin implementation matching the VCI plugin.
@@ -172,11 +172,11 @@ mosip.certify.oauth.code-challenge-methods-supported=S256
 mosip.certify.oauth.interactive-authorization-endpoint=${mosip.certify.authorization.url}${server.servlet.path}/oauth/iae
 ```
 2. **Local VP Request Configuration:** `application-local.properties` points `mosip.certify.vp-request.config-file-url` to `vp_request_config-local.json`. This file contains hardcoded `clientId` and `nonce` values that match the sample DCQL VP token used by the Postman collection, so the embedded Inji Verify library's signature / domain / challenge checks pass without regenerating a VP for every run. Deployment configurations should continue to use `vp_request_config.json` (no hardcoded `clientId` / `nonce`).
-3. Refer to the collections in [Presentation During Issuance](./postman-collections/Presentation-During-Issuance.postman_collection.json) and the respective env to test the flow.
-4. Use `Discovery Endpoints Copy` to get the issuer and oauth metadata endpoints.
-5. Use `IAR Request` to get the IAR code.
-6. Use the code to get the access token with `OAuth Token Exchange`.
-7. Use the access token to request VC issuance with `Get Credential` request inside the `Credential Download` folder.
+3. Import the **Inji Certify - Presentation During Issuance VCI** collection and the [presentation-during-issuance environment](./postman-collections/Inji-certify-presentation-during-issuance.postman_environment.json) from [docs/postman-collections](./postman-collections/) to test the flow, running the requests in order:
+4. Use the `1. Discovery Endpoints Copy` folder to fetch the issuer and OAuth authorization-server metadata endpoints.
+5. Use `2.1 Auth request` to send the Interactive Authorization Request (IAR) and receive the `openid4vp_request` carrying the DCQL query.
+6. Use `3.1 Auth Request with VP (iae_post)` to submit the `vp_token` and obtain the authorization code.
+7. Use `4.1 Successful Token Exchange` to exchange the code for an access token, `5.1 Get Nonce` to fetch the `c_nonce`, and finally `6.1 Get Credential` to request the VC.
 
 ## Locally setting up CSV Plugin
 

--- a/docs/Local-Development.md
+++ b/docs/Local-Development.md
@@ -153,6 +153,7 @@ mvn clean install -Dgpg.skip=true
 ## Setting up Presentation During Issuance
 To setup presentation requirement during issuance, follow the steps below:
 1. **Configuration:** Use the following properties in `application-local.properties` to setup presentation requirement during issuance.
+
    ```properties
    ## Use certify as Auth Server
    # Use below properties to use certify as authorization server
@@ -170,6 +171,7 @@ To setup presentation requirement during issuance, follow the steps below:
    mosip.certify.oauth.code-challenge-methods-supported=S256
    mosip.certify.oauth.interactive-authorization-endpoint=${mosip.certify.authorization.url}${server.servlet.path}/oauth/iae
    ```
+
 2. **Local VP Request Configuration:** `application-local.properties` points `mosip.certify.vp-request.config-file-url` to `vp_request_config-local.json`. This file contains hardcoded `clientId` and `nonce` values that match the sample DCQL VP token used by the Postman collection, so the embedded Inji Verify library's signature / domain / challenge checks pass without regenerating a VP for every run. Deployment configurations should continue to use `vp_request_config.json` (no hardcoded `clientId` / `nonce`).
 3. Import the **Inji Certify - Presentation During Issuance VCI** collection and the [presentation-during-issuance environment](./postman-collections/Inji-certify-presentation-during-issuance.postman_environment.json) from [docs/postman-collections](./postman-collections/) to test the flow, running the requests in order:
 4. Use the `1. Discovery Endpoints Copy` folder to fetch the issuer and OAuth authorization-server metadata endpoints.


### PR DESCRIPTION
#908 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated local development guidance for DataProvider configuration.
  * Added instructions for the new Presentation During Issuance Postman collection, environment, and ordered request workflow.
  * Documented Presentation During Issuance configuration, supporting assets, and embedded verification capabilities.
  * Removed documentation for the standalone Inji Verify service endpoint and setup instructions.
  * Updated Docker Compose references and clarified the documented directory structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->