### PR TITLE
Add validation for statusPurpose and statusListIndex in credential st… (700)

### DIFF
--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -9,6 +9,7 @@ import io.mosip.certify.entity.CredentialStatusTransaction;
 import io.mosip.certify.entity.StatusListCredential;
 import io.mosip.certify.repository.CredentialStatusTransactionRepository;
 import io.mosip.certify.repository.StatusListCredentialRepository;
+import io.mosip.certify.utils.BitStringStatusListUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,13 +60,15 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
 
     private String validateCredentialStatus(String requestedPurpose, Long statusListIndex,
                                             StatusListCredential statusListCredential) {
-        // Validate statusListIndex
+        // Validate statusListIndex using shared utility
+        // This ensures the effective 16 KB minimum and overflow/maximum checks match batch processing
+        long maxCapacity = BitStringStatusListUtils.safeConvertKBToBits(statusListCredential.getCapacityInKB());
+
         if (statusListIndex < 0) {
             throw new CertifyException(ErrorConstants.INDEX_OUT_OF_BOUNDS,
                 "statusListIndex must be non-negative, received: " + statusListIndex);
         }
 
-        long maxCapacity = statusListCredential.getCapacityInKB() * 1024L * 8L;
         if (statusListIndex >= maxCapacity) {
             throw new CertifyException(ErrorConstants.INDEX_OUT_OF_BOUNDS,
                 "statusListIndex " + statusListIndex + " exceeds maximum capacity " +

--- a/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
+++ b/certify-service/src/main/java/io/mosip/certify/services/CredentialStatusServiceImpl.java
@@ -35,12 +35,12 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
         StatusListCredential statusListCredential = statusListCredentialRepository.findById(statusListCredentialId)
                 .orElseThrow(() -> new CertifyException(ErrorConstants.STATUS_LIST_NOT_FOUND, "Status List Credential not found for ID: " + statusListCredentialId));
 
+        // Validate statusPurpose and statusListIndex
+        String validatedPurpose = validateCredentialStatus(request.getCredentialStatus().getStatusPurpose(),
+                statusListIndex, statusListCredential);
+
         CredentialStatusTransaction transaction = new CredentialStatusTransaction();
-        if(StringUtils.isEmpty(request.getCredentialStatus().getStatusPurpose())) {
-            transaction.setStatusPurpose(statusListCredential.getStatusPurpose());
-        } else {
-            transaction.setStatusPurpose(request.getCredentialStatus().getStatusPurpose());
-        }
+        transaction.setStatusPurpose(validatedPurpose);
         transaction.setStatusValue(request.getStatus());
         transaction.setStatusListCredentialId(statusListCredentialId);
         transaction.setStatusListIndex(statusListIndex);
@@ -55,5 +55,34 @@ public class CredentialStatusServiceImpl implements CredentialStatusService {
             dto.setCredentialType(request.getCredentialStatus().getType());
         }
         return dto;
+    }
+
+    private String validateCredentialStatus(String requestedPurpose, Long statusListIndex,
+                                            StatusListCredential statusListCredential) {
+        // Validate statusListIndex
+        if (statusListIndex < 0) {
+            throw new CertifyException(ErrorConstants.INDEX_OUT_OF_BOUNDS,
+                "statusListIndex must be non-negative, received: " + statusListIndex);
+        }
+
+        long maxCapacity = statusListCredential.getCapacityInKB() * 1024L * 8L;
+        if (statusListIndex >= maxCapacity) {
+            throw new CertifyException(ErrorConstants.INDEX_OUT_OF_BOUNDS,
+                "statusListIndex " + statusListIndex + " exceeds maximum capacity " +
+                maxCapacity + " for status list '" + statusListCredential.getId() + "'");
+        }
+
+        // Validate and return statusPurpose
+        if(StringUtils.isEmpty(requestedPurpose)) {
+            return statusListCredential.getStatusPurpose();
+        } else {
+            if(!requestedPurpose.equals(statusListCredential.getStatusPurpose())) {
+                throw new CertifyException(ErrorConstants.INVALID_STATUS_PURPOSE,
+                    "statusPurpose mismatch: requested '" + requestedPurpose +
+                    "' but status list '" + statusListCredential.getId() + "' has purpose '" +
+                    statusListCredential.getStatusPurpose() + "'");
+            }
+            return requestedPurpose;
+        }
     }
 }

--- a/certify-service/src/main/java/io/mosip/certify/utils/BitStringStatusListUtils.java
+++ b/certify-service/src/main/java/io/mosip/certify/utils/BitStringStatusListUtils.java
@@ -39,7 +39,7 @@ public final class BitStringStatusListUtils {
                 statusMap.size(), capacityInKB);
 
         try {
-            long actualCapacity = safeConvertKBToBits(capacityInKB);
+            long actualCapacity = safeConvertKBToBitsInternal(capacityInKB);
             BitSet bitstring = decodeEncodedList(encodedStatusList, (int) actualCapacity);
             for (Map.Entry<Long, Boolean> entry : statusMap.entrySet()) {
                 long index = entry.getKey();
@@ -74,7 +74,7 @@ public final class BitStringStatusListUtils {
      */
     public static String createEmptyEncodedList(long capacityInKB) {
         log.debug("Creating empty encoded list with capacity {}", capacityInKB);
-        long actualCapacity = safeConvertKBToBits(capacityInKB);
+        long actualCapacity = safeConvertKBToBitsInternal(capacityInKB);
         BitSet emptyBitstring = new BitSet((int) actualCapacity);
         byte[] emptyByteArray = convertBitstringToByteArray(emptyBitstring, (int) actualCapacity);
         return "u" + compressAndEncode(emptyByteArray);
@@ -172,7 +172,17 @@ public final class BitStringStatusListUtils {
      * @return Capacity in bits
      * @throws CertifyException if capacity is negative, overflow occurs, or result exceeds BitSet limits
      */
-    private static long safeConvertKBToBits(long capacityInKB) {
+    public static long safeConvertKBToBits(Long capacityInKB) {
+        // Handle null capacity
+        if (capacityInKB == null) {
+            log.error("StatusList capacity must not be null");
+            throw new CertifyException(ErrorConstants.STATUS_LIST_CAPACITY_MISCONFIGURED, "StatusList capacity must not be null");
+        }
+
+        return safeConvertKBToBitsInternal(capacityInKB);
+    }
+
+    private static long safeConvertKBToBitsInternal(long capacityInKB) {
         // Check for negative input
         if (capacityInKB < 0) {
             log.error("StatusList capacity must not be a negative value: {}", capacityInKB);

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
@@ -76,6 +76,7 @@ public class CredentialStatusServiceImplTest {
 
         StatusListCredential mockStatusListCredential = new StatusListCredential();
         mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(1024L);
 
         when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
         when(credentialStatusTransactionRepository.save(any(CredentialStatusTransaction.class)))
@@ -94,6 +95,7 @@ public class CredentialStatusServiceImplTest {
 
         StatusListCredential mockStatusListCredential = new StatusListCredential();
         mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(1024L);
 
         when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
         when(credentialStatusTransactionRepository.save(any(CredentialStatusTransaction.class)))
@@ -120,20 +122,6 @@ public class CredentialStatusServiceImplTest {
     }
 
     @Test
-    public void updateCredentialStatusV2_NullStatusListIndex_ThrowsException() {
-        String statusListCredential = "https://example.com/status-list/xyz#87823";
-        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
-        request.getCredentialStatus().setStatusListIndex(null); // Null StatusListIndex
-
-        CertifyException exception = assertThrows(CertifyException.class, () -> {
-            credentialStatusService.updateCredentialStatus(request);
-        });
-
-        assertEquals("status_list_not_found_for_the_given_id", exception.getErrorCode());
-        assertEquals("Status List Credential not found for ID: https://example.com/status-list/xyz#87823", exception.getMessage());
-    }
-
-    @Test
     public void updateCredentialStatusV2_EmptyStatusPurpose_UsesStatusListCredentialPurpose() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
@@ -141,6 +129,7 @@ public class CredentialStatusServiceImplTest {
 
         StatusListCredential mockStatusListCredential = new StatusListCredential();
         mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(1024L);
 
         when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
         when(credentialStatusTransactionRepository.save(any(CredentialStatusTransaction.class)))
@@ -163,6 +152,148 @@ public class CredentialStatusServiceImplTest {
 
         assertEquals("status_list_not_found_for_the_given_id", exception.getErrorCode());
         assertEquals("Status List Credential not found for ID: invalid-format", exception.getMessage());
+    }
+
+    @Test
+    public void updateCredentialStatusV2_InvalidStatusPurpose_ThrowsException() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+        request.getCredentialStatus().setStatusPurpose("invalid_purpose"); // Invalid status purpose
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setId(statusListCredential);
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(1024L); // 1MB capacity
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
+
+        CertifyException exception = assertThrows(CertifyException.class, () -> {
+            credentialStatusService.updateCredentialStatus(request);
+        });
+
+        assertEquals("invalid_status_purpose", exception.getErrorCode());
+        assertEquals("statusPurpose mismatch: requested 'invalid_purpose' but status list '" +
+                statusListCredential + "' has purpose 'revocation'", exception.getMessage());
+    }
+
+    @Test
+    public void updateCredentialStatusV2_MismatchedStatusPurpose_ThrowsException() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+        request.getCredentialStatus().setStatusPurpose("suspension"); // Different purpose
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setId(statusListCredential);
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(1024L); // 1MB capacity
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
+
+        CertifyException exception = assertThrows(CertifyException.class, () -> {
+            credentialStatusService.updateCredentialStatus(request);
+        });
+
+        assertEquals("invalid_status_purpose", exception.getErrorCode());
+        assertEquals("statusPurpose mismatch: requested 'suspension' but status list '" +
+                statusListCredential + "' has purpose 'revocation'", exception.getMessage());
+    }
+
+    @Test
+    public void updateCredentialStatusV2_NegativeStatusListIndex_ThrowsException() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+        request.getCredentialStatus().setStatusListIndex(-1L); // Negative index
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(1024L); // 1MB capacity
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
+
+        CertifyException exception = assertThrows(CertifyException.class, () -> {
+            credentialStatusService.updateCredentialStatus(request);
+        });
+
+        assertEquals("requested_index_is_out_of_bounds_for_status_list_capacity", exception.getErrorCode());
+        assertEquals("statusListIndex must be non-negative, received: -1", exception.getMessage());
+    }
+
+    @Test
+    public void updateCredentialStatusV2_StatusListIndexExceedsCapacity_ThrowsException() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+
+        // Set capacity to 1KB = 1024 bytes = 1024 * 8 = 8192 bits (max index is 8191)
+        long capacityInKB = 1L;
+        long maxCapacity = capacityInKB * 1024L * 8L; // 8192
+        request.getCredentialStatus().setStatusListIndex(maxCapacity + 100); // 8292 (exceeds capacity)
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(capacityInKB);
+        mockStatusListCredential.setId(statusListCredential);
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
+
+        CertifyException exception = assertThrows(CertifyException.class, () -> {
+            credentialStatusService.updateCredentialStatus(request);
+        });
+
+        assertEquals("requested_index_is_out_of_bounds_for_status_list_capacity", exception.getErrorCode());
+        assertEquals("statusListIndex " + (maxCapacity + 100) + " exceeds maximum capacity " +
+                maxCapacity + " for status list '" + statusListCredential + "'", exception.getMessage());
+    }
+
+    @Test
+    public void updateCredentialStatusV2_StatusListIndexAtMaxCapacity_ThrowsException() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+
+        // Set capacity to 1KB = 1024 bytes = 1024 * 8 = 8192 bits (max index is 8191)
+        long capacityInKB = 1L;
+        long maxCapacity = capacityInKB * 1024L * 8L; // 8192
+        request.getCredentialStatus().setStatusListIndex(maxCapacity); // 8192 (exactly at boundary, should fail)
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(capacityInKB);
+        mockStatusListCredential.setId(statusListCredential);
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
+
+        CertifyException exception = assertThrows(CertifyException.class, () -> {
+            credentialStatusService.updateCredentialStatus(request);
+        });
+
+        assertEquals("requested_index_is_out_of_bounds_for_status_list_capacity", exception.getErrorCode());
+        assertEquals("statusListIndex " + maxCapacity + " exceeds maximum capacity " +
+                maxCapacity + " for status list '" + statusListCredential + "'", exception.getMessage());
+    }
+
+    @Test
+    public void updateCredentialStatusV2_StatusListIndexAtMaxCapacityMinusOne_Success() {
+        String statusListCredential = "https://example.com/status-list/xyz#87823";
+        UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
+
+        // Set capacity to 1KB = 1024 bytes = 1024 * 8 = 8192 bits (max valid index is 8191)
+        long capacityInKB = 1L;
+        long maxCapacity = capacityInKB * 1024L * 8L; // 8192
+        request.getCredentialStatus().setStatusListIndex(maxCapacity - 1); // 8191 (valid boundary)
+
+        StatusListCredential mockStatusListCredential = new StatusListCredential();
+        mockStatusListCredential.setStatusPurpose("revocation");
+        mockStatusListCredential.setCapacityInKB(capacityInKB);
+        mockStatusListCredential.setId(statusListCredential);
+
+        when(statusListCredentialRepository.findById(statusListCredential)).thenReturn(Optional.of(mockStatusListCredential));
+        when(credentialStatusTransactionRepository.save(any(CredentialStatusTransaction.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        CredentialStatusResponse response = credentialStatusService.updateCredentialStatus(request);
+
+        assertNotNull(response);
+        assertEquals(maxCapacity - 1, response.getStatusListIndex());
+        assertEquals("revocation", response.getStatusPurpose());
     }
 
     private UpdateCredentialStatusRequest createValidUpdateCredentialRequest(String statusListCredential) {

--- a/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
+++ b/certify-service/src/test/java/io/mosip/certify/services/CredentialStatusServiceImplTest.java
@@ -155,7 +155,7 @@ public class CredentialStatusServiceImplTest {
     }
 
     @Test
-    public void updateCredentialStatusV2_InvalidStatusPurpose_ThrowsException() {
+    public void should_throwInvalidStatusPurposeException_when_statusPurposeIsInvalid() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
         request.getCredentialStatus().setStatusPurpose("invalid_purpose"); // Invalid status purpose
@@ -177,7 +177,7 @@ public class CredentialStatusServiceImplTest {
     }
 
     @Test
-    public void updateCredentialStatusV2_MismatchedStatusPurpose_ThrowsException() {
+    public void should_throwInvalidStatusPurposeException_when_statusPurposeMismatchesStatusList() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
         request.getCredentialStatus().setStatusPurpose("suspension"); // Different purpose
@@ -199,7 +199,7 @@ public class CredentialStatusServiceImplTest {
     }
 
     @Test
-    public void updateCredentialStatusV2_NegativeStatusListIndex_ThrowsException() {
+    public void should_throwIndexOutOfBoundsException_when_statusListIndexIsNegative() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
         request.getCredentialStatus().setStatusListIndex(-1L); // Negative index
@@ -219,14 +219,15 @@ public class CredentialStatusServiceImplTest {
     }
 
     @Test
-    public void updateCredentialStatusV2_StatusListIndexExceedsCapacity_ThrowsException() {
+    public void should_throwIndexOutOfBoundsException_when_statusListIndexExceedsCapacity() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
 
-        // Set capacity to 1KB = 1024 bytes = 1024 * 8 = 8192 bits (max index is 8191)
-        long capacityInKB = 1L;
-        long maxCapacity = capacityInKB * 1024L * 8L; // 8192
-        request.getCredentialStatus().setStatusListIndex(maxCapacity + 100); // 8292 (exceeds capacity)
+        // Set capacity to 20KB (above 16KB minimum)
+        // 20KB = 20 * 1024 * 8 = 163840 bits (max index is 163839)
+        long capacityInKB = 20L;
+        long maxCapacity = capacityInKB * 1024L * 8L; // 163840
+        request.getCredentialStatus().setStatusListIndex(maxCapacity + 100); // 163940 (exceeds capacity)
 
         StatusListCredential mockStatusListCredential = new StatusListCredential();
         mockStatusListCredential.setStatusPurpose("revocation");
@@ -245,14 +246,15 @@ public class CredentialStatusServiceImplTest {
     }
 
     @Test
-    public void updateCredentialStatusV2_StatusListIndexAtMaxCapacity_ThrowsException() {
+    public void should_throwIndexOutOfBoundsException_when_statusListIndexIsAtMaxCapacityBoundary() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
 
-        // Set capacity to 1KB = 1024 bytes = 1024 * 8 = 8192 bits (max index is 8191)
-        long capacityInKB = 1L;
-        long maxCapacity = capacityInKB * 1024L * 8L; // 8192
-        request.getCredentialStatus().setStatusListIndex(maxCapacity); // 8192 (exactly at boundary, should fail)
+        // Set capacity to 20KB (above 16KB minimum)
+        // 20KB = 20 * 1024 * 8 = 163840 bits (max index is 163839)
+        long capacityInKB = 20L;
+        long maxCapacity = capacityInKB * 1024L * 8L; // 163840
+        request.getCredentialStatus().setStatusListIndex(maxCapacity); // 163840 (exactly at boundary, should fail)
 
         StatusListCredential mockStatusListCredential = new StatusListCredential();
         mockStatusListCredential.setStatusPurpose("revocation");
@@ -271,14 +273,15 @@ public class CredentialStatusServiceImplTest {
     }
 
     @Test
-    public void updateCredentialStatusV2_StatusListIndexAtMaxCapacityMinusOne_Success() {
+    public void should_updateCredentialStatusSuccessfully_when_statusListIndexIsAtMaxValidBoundary() {
         String statusListCredential = "https://example.com/status-list/xyz#87823";
         UpdateCredentialStatusRequest request = createValidUpdateCredentialRequest(statusListCredential);
 
-        // Set capacity to 1KB = 1024 bytes = 1024 * 8 = 8192 bits (max valid index is 8191)
-        long capacityInKB = 1L;
-        long maxCapacity = capacityInKB * 1024L * 8L; // 8192
-        request.getCredentialStatus().setStatusListIndex(maxCapacity - 1); // 8191 (valid boundary)
+        // Set capacity to 20KB (above 16KB minimum)
+        // 20KB = 20 * 1024 * 8 = 163840 bits (max valid index is 163839)
+        long capacityInKB = 20L;
+        long maxCapacity = capacityInKB * 1024L * 8L; // 163840
+        request.getCredentialStatus().setStatusListIndex(maxCapacity - 1); // 163839 (valid boundary)
 
         StatusListCredential mockStatusListCredential = new StatusListCredential();
         mockStatusListCredential.setStatusPurpose("revocation");


### PR DESCRIPTION
Fixes - [issue-700](https://github.com/inji/inji-certify/issues/700)

# Add validation for statusPurpose and statusListIndex in credential status updates

## Summary
This PR adds comprehensive validation for `statusPurpose` and `statusListIndex` parameters in the credential status update endpoint (`/credentials/status`) as part of **INJICERT-1260**.

## Changes Made

### Implementation (`CredentialStatusServiceImpl.java`)
- Added `validateCredentialStatus()` method to validate both `statusPurpose` and `statusListIndex`


### Tests (`CredentialStatusServiceImplTest.java`)
Added 6 comprehensive test cases covering:
1. Invalid/random statusPurpose value
2. Mismatched statusPurpose (e.g., "suspension" vs "revocation")
3. Negative statusListIndex (-1)
4. statusListIndex exceeding capacity (capacity + 100)
5. statusListIndex at exact capacity boundary (should fail)
6. statusListIndex at max valid boundary (capacity - 1, should succeed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Credential status updates now reject negative indexes and indexes beyond the status list capacity.
  * Status-purpose mismatches are rejected, while an unspecified purpose continues to use the status list’s purpose.
  * Validation now correctly accepts the maximum valid status-list index.
  * Invalid credential status requests now receive clear validation errors instead of being processed with unsupported indexes or purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->